### PR TITLE
added fixes for ec2_ebs_default_encryption ec2_instance_managed_by_ssm

### DIFF
--- a/library/aws/checks/ec2/ec2_ebs_default_encryption.py
+++ b/library/aws/checks/ec2/ec2_ebs_default_encryption.py
@@ -23,8 +23,10 @@ class ec2_ebs_default_encryption(Check):
 
         try:
             # Fetch EBS default encryption status
-            res = client.describe_account_attributes(AttributeNames=['defaultEBSEncryption'])
-            default_encryption_enabled = res['AccountAttributes'][0]['AttributeValues'][0]['Value'] == 'true'
+            
+            res = client.get_ebs_encryption_by_default()
+            print(res)
+            default_encryption_enabled = res.get('EbsEncryptionByDefault', False)
 
             report.resource_ids_status['Default EBS Encryption'] = default_encryption_enabled
 

--- a/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
+++ b/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
@@ -1,7 +1,6 @@
 """
-AUTHOR: Deepak Puri
-EMAIL: deepak.puri@comprinno.net
-DATE: 2024-10-09
+AUTHOR: Sheikh Aafaq Rashid
+DATE: 10-10-2024
 """
 
 import boto3
@@ -29,7 +28,13 @@ class ec2_instance_managed_by_ssm(Check):
             report.passed = False
             return report
 
-        # Check each instance
+        # Remove instances in states ["pending", "terminated", "stopped"]
+        instances = [
+            instance for instance in instances 
+            if instance['State']['Name'] not in ["pending", "terminated", "stopped"]
+        ]
+
+        # Check if there are instances
         if not instances:
             report.passed = False
             report.resource_ids_status['No Instances'] = False  # No instances available
@@ -38,11 +43,6 @@ class ec2_instance_managed_by_ssm(Check):
         for instance in instances:
             instance_id = instance['InstanceId']
             report.resource_ids_status[instance_id] = True  # Assume managed initially
-            
-            # Check the state of the instance
-            if instance['State']['Name'] in ["pending", "terminated", "stopped"]:
-                report.resource_ids_status[instance_id] = False  # Mark as unmanaged due to state
-                continue  # Skip to next instance
 
             # Check if the instance is managed by SSM
             try:
@@ -56,5 +56,5 @@ class ec2_instance_managed_by_ssm(Check):
             except Exception as e:
                 report.passed = False
                 report.resource_ids_status[instance_id] = False
-                
+
         return report


### PR DESCRIPTION
This PR includes fixes for two checks: ec2_ebs_default_encryption and ec2_instance_managed_by_ssm.

Changes:
**ec2_instance_managed_by_ssm Check:**

Filtered out EC2 instances that are in the states **["pending", "terminated", "stopped"]** before performing further checks.
This ensures that instances in non-active states are not processed, improving efficiency and reducing unnecessary API calls.
The logic now removes instances in these states from the list of instances before checking if they are managed by SSM.

**ec2_ebs_default_encryption Check:**

Fixed issues related to the validation of default EBS encryption settings, ensuring that the check accurately reports instances where the default encryption is not enabled for EBS volumes.