### PR TITLE
Feat: set check status based on the resource_ids_status

### DIFF
--- a/tevico/engine/entities/check/check.py
+++ b/tevico/engine/entities/check/check.py
@@ -22,6 +22,12 @@ class Check(ABC):
         check_report.check_metadata = self.metadata
         check_report.framework = framework
         check_report.section = section
+        
+        # Set the check status based on resource_ids_status
+        if check_report.has_failed_resources():
+            check_report.passed = False
+        else:
+            check_report.passed = True
         return check_report
     
     @abstractmethod

--- a/tevico/engine/entities/report/check_model.py
+++ b/tevico/engine/entities/report/check_model.py
@@ -63,3 +63,6 @@ class CheckReport(BaseModel):
     resource_ids_status: Dict[str, bool] = {}
     report_metadata: Optional[Dict[str, Any]] = None
     created_on: datetime = datetime.now()
+
+    def has_failed_resources(self):
+        return any(status == False for status in self.resource_ids_status.values())


### PR DESCRIPTION
### Context

This pull request (PR) addresses the need to set the check status to pass/failed based on the `resource_ids_status` key inside the `CheckReport` class. This ensures that if any resource has a failed status, the overall check status is marked as failed.

---

### Description

This PR includes the following changes:

Added a method `has_failed_resources` to the `CheckReport` class to determine if any `resource_ids_status` key is False.
Modified the `get_report` method in the `Check` class to set the `passed` key based on the result of `has_failed_resources`.
No additional dependencies are required for this change.

---

### Checklist

- **New Checks**:
  - Are there new checks included in this PR? **Yes / No**
    - If yes, do we need to update permissions for the provider? Please review this carefully.

- **Testing**:
  - [ ] Verify if the new code is covered by tests.
    - The code was tested and verified by running the checks and the report was reflecting the expected check status (If any of the resource id has a failed status the check was also marked as failed)

- **Documentation**:
  - [ ] Confirm that the code is documented following the [Google Python Style Guide](https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings).

- **Backport**:
  - [ ] Review if backporting is necessary for this change.

---

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the **Apache 2.0 license**.