### PR TITLE
Detect Inline Policies with Admin Privileges in IAM Users

### DIFF
--- a/library/aws/checks/iam/iam_inline_policy_admin_privileges_found.py
+++ b/library/aws/checks/iam/iam_inline_policy_admin_privileges_found.py
@@ -1,3 +1,9 @@
+"""
+AUTHOR: Sheikh Aafaq Rashid
+EMAIL: aafaq.rashid@comprinno.net
+DATE: 2025-1-7
+"""
+
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError
 from tevico.engine.entities.report.check_model import CheckReport

--- a/library/aws/checks/iam/iam_inline_policy_admin_privileges_found.py
+++ b/library/aws/checks/iam/iam_inline_policy_admin_privileges_found.py
@@ -1,81 +1,114 @@
-"""
-AUTHOR: RONIT CHAUHAN 
-DATE: 2024-10-11
-"""
-
 import boto3
+from botocore.exceptions import BotoCoreError, ClientError
 from tevico.engine.entities.report.check_model import CheckReport
 from tevico.engine.entities.check.check import Check
 
+
 class iam_inline_policy_admin_privileges_found(Check):
+
     def execute(self, connection: boto3.Session) -> CheckReport:
+        """
+        Check IAM users, groups, and roles for inline policies with administrative privileges.
+
+        :param connection: boto3 session
+        :return: CheckReport
+        """
+        # Initialize IAM client
+        client = connection.client('iam')
+
         report = CheckReport(name=__name__)
+        report.passed = True  # Default to passed until an admin inline policy is found
+        report.resource_ids_status = {}
 
-        # Initialize the IAM client
-        iam_client = connection.client('iam')
-        # print("[INFO] Initialized IAM client.")
+        def has_admin_privileges(policy_document):
+            """Check if the policy document grants admin privileges."""
+            statements = policy_document.get('Statement', [])
+            if not isinstance(statements, list):
+                statements = [statements]
+            for statement in statements:
+                if (
+                    statement.get('Effect') == 'Allow' and
+                    statement.get('Action') == '*' and
+                    statement.get('Resource') == '*'
+                ):
+                    return True
+            return False
 
-        # Fetch all users
-        users = iam_client.list_users()['Users']
-        # print(f"[INFO] Retrieved {len(users)} IAM users.")
-        
-        findings = []
+        def process_entities(entity_type, list_func, policy_list_func, policy_get_func, name_key):
+            """
+            Generic function to process users, groups, or roles for inline policies.
 
-        for user in users:
-            user_name = user['UserName']
-            # print(f"[INFO] Processing IAM user: {user_name}")
+            :param entity_type: Entity type ('User', 'Group', 'Role')
+            :param list_func: Function to list entities
+            :param policy_list_func: Function to list policies for the entity
+            :param policy_get_func: Function to get a policy document
+            :param name_key: Key to extract the entity name
+            """
+            try:
+                paginator = client.get_paginator(list_func)
+                for page in paginator.paginate():
+                    for entity in page[entity_type + 's']:
+                        entity_name = entity[name_key]
+                        failed_policies = []  # List to store failed policy names
 
-            # Check inline policies for the user
-            inline_policies = iam_client.list_user_policies(UserName=user_name)['PolicyNames']
-            # print(f"[INFO] {user_name} has {len(inline_policies)} inline policies.")
+                        try:
+                            policies = client.__getattribute__(policy_list_func)(
+                                **{entity_type + 'Name': entity_name}
+                            )['PolicyNames']
 
-            for policy_name in inline_policies:
-                # print(f"[INFO] Fetching details for inline policy: {policy_name}")
+                            # Check each policy for admin privileges
+                            for policy_name in policies:
+                                policy_document = client.__getattribute__(policy_get_func)(
+                                    **{entity_type + 'Name': entity_name, 'PolicyName': policy_name}
+                                )['PolicyDocument']
 
-                # Get the inline policy document
-                policy_document = iam_client.get_user_policy(UserName=user_name, PolicyName=policy_name)['PolicyDocument']
+                                if has_admin_privileges(policy_document):
+                                    # Add the failed policy name to the list
+                                    failed_policies.append(policy_name)
+                                    report.passed = False
 
-                # Check if the inline policy grants full administrative privileges
-                if 'Statement' in policy_document:
-                    for statement in policy_document['Statement']:
-                        if statement.get('Effect') == 'Allow':
-                            actions = statement.get('Action', [])
-                            resources = statement.get('Resource', [])
-                            
-                            # Check if actions allow all actions and resources
-                            if actions == "*" and resources == "*":
-                                # print(f"[WARNING] Inline policy {policy_name} grants full administrative privileges to user {user_name}.")
-                                findings.append(f"User {user_name} has inline policy {policy_name} with full administrative privileges.")
-                                break  # Stop after detecting full admin privileges
-                            elif isinstance(actions, list) and "*" in actions and isinstance(resources, list) and "*" in resources:
-                                # print(f"[WARNING] Inline policy {policy_name} grants full administrative privileges to user {user_name}.")
-                                findings.append(f"User {user_name} has inline policy {policy_name} with full administrative privileges.")
-                                break  # Stop after detecting full admin privileges
-                    else:
-                        # print(f"[INFO] Inline policy {policy_name} does not grant full administrative privileges.")
-                        pass
-                else:
-                    # print(f"[INFO] No statements found in policy {policy_name}.")
-                    pass
+                            # If there were failed policies, store them as a comma-separated list
+                            if failed_policies:
+                                # Store the status as False and append policy names
+                                report.resource_ids_status[f"{entity_type}::{entity_name} has inline policy {', '.join(failed_policies)} with full administrative privileges." ] = False
+                                
+                            # If no failed policies, store the success status as True
+                            elif f"{entity_type}::{entity_name}" not in report.resource_ids_status:
+                                report.resource_ids_status[f"{entity_type}::{entity_name} has not any inline policy with full administrative privileges."] = True
 
-        # Determine report status based on findings
-        if findings:
-            report.passed = False  # Indicate that the check failed
-            report.resource_ids_status = {user['UserName']: False for user in users}  # Mark users as having issues
-            report.report_metadata = {"findings": findings}  # Store findings in report metadata
-            # print(f"[FAIL] Administrative privileges found for {len(findings)} policies.")
-        else:
-            report.passed = True  # Indicate that the check passed
-            report.resource_ids_status = {user['UserName']: True for user in users}  # Mark all users as having no issues
-            # print("[PASS] No administrative privileges found in inline policies.")
+                        except (BotoCoreError, ClientError):
+                            # Mark as fail on error and add to the status
+                            report.passed = False
+                            report.resource_ids_status[f"{entity_type}::{entity_name}"] = False
+            except (BotoCoreError, ClientError):
+                report.passed = False
+
+        # Process IAM users, groups, and roles
+        process_entities(
+            entity_type='User',
+            list_func='list_users',
+            policy_list_func='list_user_policies',
+            policy_get_func='get_user_policy',
+            name_key='UserName'
+        )
+        # Uncomment and extend to process groups and roles
+        # process_entities(
+        #     entity_type='Group',
+        #     list_func='list_groups',
+        #     policy_list_func='list_group_policies',
+        #     policy_get_func='get_group_policy',
+        #     name_key='GroupName'
+        # )
+        # process_entities(
+        #     entity_type='Role',
+        #     list_func='list_roles',
+        #     policy_list_func='list_role_policies',
+        #     policy_get_func='get_role_policy',
+        #     name_key='RoleName'
+        # )
+                # If any failure was found, the check should fail
+                if any(status is False for status in report.resource_ids_status.values()):
+                    report.passed = False  # Ensure this is a boolean
 
         return report
-
-# The check fails if any user has an inline policy that grants full administrative privileges (i.e., Action and Resource both set to "*"). 
-# It passes if no such inline policies are found for any users.
-
-
-
-
-
-
+ 


### PR DESCRIPTION
### Description: Detect Admin Privileges in IAM User Inline Policies  

#### **Objective**  
This PR adds a check to identify IAM users with inline policies granting full administrative privileges (`Action: "*"`, `Resource: "*"`, `Effect: "Allow"`).  

#### **Details**  
- Focused on **IAM users only**.  
- Detects and flags users with overly permissive inline policies.  
- Reports compliance status for each user.  
- Handles API errors gracefully to ensure smooth execution.  

#### **Output Examples**  
- **Compliant**: `User::test_user has not any inline policy with full administrative privileges.`  
- **Non-compliant**: `User::admin_user has inline policy "AdminAccess" with full administrative privileges.`  
