### PR TITLE
Fixed indentation issue in if any failure was found, the check should fail logic block.

### DIFF
--- a/library/aws/checks/iam/iam_inline_policy_admin_privileges_found.py
+++ b/library/aws/checks/iam/iam_inline_policy_admin_privileges_found.py
@@ -112,9 +112,9 @@ class iam_inline_policy_admin_privileges_found(Check):
         #     policy_get_func='get_role_policy',
         #     name_key='RoleName'
         # )
-                # If any failure was found, the check should fail
-                if any(status is False for status in report.resource_ids_status.values()):
-                    report.passed = False  # Ensure this is a boolean
+        # If any failure was found, the check should fail
+        if any(status is False for status in report.resource_ids_status.values()):
+            report.passed = False  # Ensure this is a boolean
 
         return report
  


### PR DESCRIPTION

**Details:**  
This PR addresses an indentation issue in the code block responsible for determining the status of the check based on inline policy evaluation results. Specifically, it ensures the correct indentation of the following lines:  
```python
if any(status is False for status in report.resource_ids_status.values()):
    report.passed = False  # Ensure this is a boolean
```