### PR TITLE
Enhance CloudFront Security: Check for HTTPS and Deprecated SSL Protocols

### DIFF
--- a/library/aws/checks/cloudfront/cloudfront_distributions_https_enabled.py
+++ b/library/aws/checks/cloudfront/cloudfront_distributions_https_enabled.py
@@ -1,34 +1,63 @@
 """
-AUTHOR: deepak-puri-comprinno
-EMAIL: deepak.puri@comprinno.net
-DATE: 2024-11-15
+AUTHOR: Sheikh Aafaq Rashid
+EMAIL: aafaq.rashid@comprinno.net
+DATE: 2025-01-09
 """
-
 import boto3
+
 from tevico.engine.entities.report.check_model import CheckReport
 from tevico.engine.entities.check.check import Check
 
+
 class cloudfront_distributions_https_enabled(Check):
+
     def execute(self, connection: boto3.Session) -> CheckReport:
+
+        # Initialize CloudFront client
         client = connection.client('cloudfront')
+
         report = CheckReport(name=__name__)
+
+        # Initialize report status as 'Passed' unless we find a distribution without HTTPS enabled
         report.passed = True
-        distributions = client.list_distributions()
-        
-        if ('DistributionList' in distributions and 
-            'Items' in distributions['DistributionList'] and 
-            distributions['DistributionList']['Items']):
-            
-            for distribution in distributions['DistributionList']['Items']:
+        report.resource_ids_status = {}
+
+        try:
+            # Initialize pagination
+            distributions = []
+            next_marker = None
+
+            while True:
+                # Fetch distributions with pagination
+                if next_marker:
+                    res = client.list_distributions(Marker=next_marker)
+                else:
+                    res = client.list_distributions()
+
+                distributions.extend(res.get('DistributionList', {}).get('Items', []))
+                next_marker = res.get('NextMarker', None)
+
+                if not next_marker:
+                    break
+
+            # Iterate over distributions to check HTTPS status
+            for distribution in distributions:
                 distribution_id = distribution['Id']
                 default_cache_behavior = distribution.get('DefaultCacheBehavior', {})
-                viewer_protocol_policy = default_cache_behavior.get('ViewerProtocolPolicy', '')
-                if viewer_protocol_policy != 'redirect-to-https' and viewer_protocol_policy != 'https-only':
-                    report.resource_ids_status[distribution_id] = False
-                    report.passed = False
+                viewer_protocol_policy = default_cache_behavior.get('ViewerProtocolPolicy', 'allow-all')
+       
+
+                # Log the HTTPS status of each distribution (True or False
+                if viewer_protocol_policy in ['redirect-to-https', 'https-only']:
+                    report.passed = True  # Mark report as 'Failed' if any distribution is not using HTTPS
+                    report.resource_ids_status[f"{distribution_id} has  {viewer_protocol_policy}."] = True
                 else:
-                    report.resource_ids_status[distribution_id] = True
-        else:
-            report.resource_ids_status['NoDistributions'] = True
+                    report.passed = False  # Mark report as 'Failed' if any distribution is not using HTTPS
+                    report.resource_ids_status[f"{distribution_id} has  {viewer_protocol_policy}."] = False
+                    
+
+        except Exception as e:
+            report.passed = False
+            report.resource_ids_status = {}
 
         return report

--- a/library/aws/checks/cloudfront/cloudfront_distributions_using_deprecated_ssl_protocols.py
+++ b/library/aws/checks/cloudfront/cloudfront_distributions_using_deprecated_ssl_protocols.py
@@ -1,36 +1,57 @@
-"""
-AUTHOR: deepak-puri-comprinno
-EMAIL: deepak.puri@comprinno.net
-DATE: 2024-11-15
-"""
-
 import boto3
+
 from tevico.engine.entities.report.check_model import CheckReport
 from tevico.engine.entities.check.check import Check
 
+
 class cloudfront_distributions_using_deprecated_ssl_protocols(Check):
+
     def execute(self, connection: boto3.Session) -> CheckReport:
+
+        # Initialize CloudFront client
         client = connection.client('cloudfront')
+
         report = CheckReport(name=__name__)
-        report.passed = True
 
-        # List CloudFront distributions
-        distributions = client.list_distributions()
-        deprecated_protocols = ['SSLv3', 'TLSv1', 'TLSv1.1']
+        # Initialize report status as 'Passed' unless we find a distribution using deprecated SSL protocols
+        report.passed = "Passed"
+        report.resource_ids_status = {}
 
-        if ('DistributionList' in distributions and 
-            'Items' in distributions['DistributionList'] and 
-            distributions['DistributionList']['Items']):
-            
-            for distribution in distributions['DistributionList']['Items']:
-                distribution_id = distribution['Id']
-                viewer_certificate = distribution.get('ViewerCertificate', {})
+        try:
+            # Initialize pagination
+            distributions = []
+            next_marker = None
 
-                minimum_protocol_version = viewer_certificate.get('MinimumProtocolVersion', '')
-                if minimum_protocol_version in deprecated_protocols:
-                    report.resource_ids_status[distribution_id] = False
-                    report.passed = False
+            while True:
+                # Fetch distributions with pagination
+                if next_marker:
+                    res = client.list_distributions(Marker=next_marker)
                 else:
-                    report.resource_ids_status[distribution_id] = True
+                    res = client.list_distributions()
+
+                distributions.extend(res.get('DistributionList', {}).get('Items', []))
+                next_marker = res.get('NextMarker', None)
+
+                if not next_marker:
+                    break
+
+            # Iterate over distributions to check SSL protocols
+            for distribution in distributions:
+                distribution_id = distribution['Id']
+                # Fetch the SSL configuration for the distribution
+                viewer_certificate = distribution.get('ViewerCertificate', {})
+                ssl_protocols = viewer_certificate.get('MinimumProtocolVersion')
+                
+
+                # Check for deprecated SSL protocols (TLSv1, TLSv1.1, SSLv3)
+                if ssl_protocols in ['TLSv1', 'TLSv1.1', 'SSLv3']:
+                    report.resource_ids_status[f"{distribution_id} uses the deprecated SSL protocol {ssl_protocols}."] = False
+                    report.passed = False  # Mark report as 'Failed' if any distribution is using deprecated SSL protocols
+                else:
+                    report.resource_ids_status[f"{distribution_id} uses {ssl_protocols}, not a deprecated SSL protocol."] = True
+
+        except Exception as e:
+            report.passed = "Failed"
+            report.resource_ids_status = {}
 
         return report

--- a/library/aws/checks/cloudfront/cloudfront_distributions_using_deprecated_ssl_protocols.py
+++ b/library/aws/checks/cloudfront/cloudfront_distributions_using_deprecated_ssl_protocols.py
@@ -1,3 +1,9 @@
+"""
+AUTHOR: Sheikh Aafaq Rashid
+EMAIL: aafaq.rashid@comprinno.net
+DATE: 2025-01-09
+"""
+
 import boto3
 
 from tevico.engine.entities.report.check_model import CheckReport


### PR DESCRIPTION
### Description:

This PR introduces two checks for AWS CloudFront distributions to enhance security:

1. **HTTPS Enabled Check**: 
   - Ensures CloudFront distributions are configured to use HTTPS by either redirecting HTTP traffic to HTTPS or allowing only HTTPS traffic. Distributions not using HTTPS will be flagged as failed.
   - A new class `cloudfront_distributions_https_enabled` checks the `ViewerProtocolPolicy` for each distribution.

2. **Deprecated SSL Protocols Check**:
   - Ensures CloudFront distributions are not using deprecated SSL protocols (TLSv1, TLSv1.1, SSLv3). Any distribution using these protocols will be flagged as failed.
   - A new class `cloudfront_distributions_using_deprecated_ssl_protocols` checks the `MinimumProtocolVersion` of each distribution's viewer certificate.

Both checks help enforce security best practices by ensuring that CloudFront distributions use secure, up-to-date protocols and HTTPS.