### PR TITLE
Updated ACM Checks

### DIFF
--- a/library/aws/checks/acm/acm_certificates_expiration_check.py
+++ b/library/aws/checks/acm/acm_certificates_expiration_check.py
@@ -1,42 +1,79 @@
 """
 AUTHOR: deepak-puri-comprinno
 EMAIL: deepak.puri@comprinno.net
-DATE: 2024-11-12
+DATE: 2025-01-09
+
 """
 
 import boto3
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from tevico.engine.entities.report.check_model import CheckReport
 from tevico.engine.entities.check.check import Check
 
+
 class acm_certificates_expiration_check(Check):
+
+    # Default threshold for certificate expiration warning (in days)
+    EXPIRATION_THRESHOLD_DAYS = 7
+
     def execute(self, connection: boto3.Session) -> CheckReport:
+
+        # Initialize ACM client and check report
         client = connection.client('acm')
         report = CheckReport(name=__name__)
         report.passed = True
-        threshold_days = 7  # Expiration threshold in days
+        report.resource_ids_status = {}
 
-        # List all ACM certificates
-        paginator = client.get_paginator('list_certificates')
-        for page in paginator.paginate():
-            certificates = page['CertificateSummaryList']
-            for cert in certificates:
-                cert_arn = cert['CertificateArn']
-                
-                # Get certificate details
-                cert_details = client.describe_certificate(CertificateArn=cert_arn)
-                not_after = cert_details['Certificate']['NotAfter']
-                
-                # Convert current time to timezone-aware for comparison
-                current_time = datetime.now(timezone.utc)
-                
-                # Check if the certificate expires within the threshold
-                days_until_expiration = (not_after - current_time).days
-                if days_until_expiration <= threshold_days:
-                    report.resource_ids_status[cert_arn] = False
-                    report.passed = False
-                else:
-                    report.resource_ids_status[cert_arn] = True
+        try:
+            # Use paginator to list all ACM certificates
+            paginator = client.get_paginator('list_certificates')
+            certificates_found = False
+
+            for page in paginator.paginate():
+                certificates = page.get('CertificateSummaryList', [])
+
+                if certificates:
+                    certificates_found = True
+
+                for cert in certificates:
+                    cert_arn = cert.get('CertificateArn')
+
+                    try:
+                        # Describe each certificate to get expiration details
+                        cert_details = client.describe_certificate(CertificateArn=cert_arn)
+                        print(cert_details)
+                        not_after = cert_details['Certificate'].get('NotAfter')
+
+                        if not_after:
+                            # Calculate days until expiration
+                            current_time = datetime.now(timezone.utc)
+                            days_until_expiration = (not_after - current_time).days
+
+                            # Handle expired certificates gracefully
+                            if days_until_expiration < 0:
+                                report.resource_ids_status[f"Certificate {cert_arn} has already expired ({-days_until_expiration} days ago)."] = False
+                                report.passed = False
+                            else:
+                                # Determine if certificate is within expiration threshold
+                                is_valid = days_until_expiration > self.EXPIRATION_THRESHOLD_DAYS
+                                report.resource_ids_status[f"Certificate {cert_arn} expires in {days_until_expiration} days."] = is_valid
+
+                                # If any certificate is expiring soon, mark the check as failed
+                                if not is_valid:
+                                    report.passed = False
+
+                    except Exception as e:
+                        # Handle errors while describing a certificate
+                        report.resource_ids_status[f"Error describing {cert_arn}"] = False
+                        report.passed = False
+
+            if not certificates_found:
+                # No certificates found, mark the check as passed
+                report.resource_ids_status["No ACM certificates found"] = True
+
+        except Exception as e:
+            # Handle errors while listing certificates
+            report.passed = False
+            report.resource_ids_status["ACM listing error"] = False
 
         return report
-

--- a/library/aws/checks/acm/acm_certificates_transparency_logs_enabled.py
+++ b/library/aws/checks/acm/acm_certificates_transparency_logs_enabled.py
@@ -1,7 +1,7 @@
 """
 AUTHOR: deepak-puri-comprinno
 EMAIL: deepak.puri@comprinno.net
-DATE: 2024-11-12
+DATE: 2025-01-09
 """
 
 import boto3
@@ -9,27 +9,60 @@ from tevico.engine.entities.report.check_model import CheckReport
 from tevico.engine.entities.check.check import Check
 
 class acm_certificates_transparency_logs_enabled(Check):
+
     def execute(self, connection: boto3.Session) -> CheckReport:
-        client = connection.client('acm')
+
+        # Initialize report and certificates list
         report = CheckReport(name=__name__)
         report.passed = True
+        report.resource_ids_status = {}
 
-        # List all ACM certificates
-        paginator = client.get_paginator('list_certificates')
-        for page in paginator.paginate():
-            certificates = page['CertificateSummaryList']
-            for cert in certificates:
-                cert_arn = cert['CertificateArn']
-                
-                # Get certificate details
-                cert_details = client.describe_certificate(CertificateArn=cert_arn)
-                transparency_logging = cert_details['Certificate'].get('Options', {}).get('CertificateTransparencyLoggingPreference', 'ENABLED')
-                
-                # Check if transparency logging is enabled
-                if transparency_logging == 'ENABLED':
-                    report.resource_ids_status[cert_arn] = True
-                else:
-                    report.resource_ids_status[cert_arn] = False
-                    report.passed = False
+        try:
+            # Initialize ACM client
+            client = connection.client('acm')
+            certificates_found = False
+
+            try:
+                # List all ACM certificates using pagination
+                paginator = client.get_paginator('list_certificates')
+                for page in paginator.paginate():
+                    certificates = page.get('CertificateSummaryList', [])
+
+                    if certificates:
+                        certificates_found = True
+
+                    # Process each certificate
+                    for cert in certificates:
+                        cert_arn = cert.get('CertificateArn')
+
+                        try:
+                            # Get detailed certificate information
+                            cert_details = client.describe_certificate(CertificateArn=cert_arn)
+                            transparency_logging = cert_details.get('Certificate', {}).get('Options', {}).get('CertificateTransparencyLoggingPreference', 'ENABLED')
+
+                            if transparency_logging != 'ENABLED':
+                                report.resource_ids_status[f"Certificate {cert_arn} has transparency logging disabled."] = False
+                                report.passed = False
+                            else:
+                                report.resource_ids_status[f"Certificate {cert_arn} has transparency logging enabled."] = True
+
+                        except Exception as e:
+                            # Handle errors in getting certificate details
+                            report.resource_ids_status[f"Error describing {cert_arn}"] = False
+                            report.passed = False
+
+            except Exception as e:
+                # Handle errors in listing certificates
+                report.resource_ids_status["ACM listing error"] = False
+                report.passed = False
+
+            if not certificates_found:
+                # No certificates found, mark the check as passed
+                report.resource_ids_status["No ACM certificates found"] = True
+
+        except Exception as e:
+            # Handle any unexpected errors
+            report.resource_ids_status["Unexpected error"] = False
+            report.passed = False
 
         return report

--- a/library/aws/frameworks/well_architected_review.yaml
+++ b/library/aws/frameworks/well_architected_review.yaml
@@ -80,6 +80,7 @@ sections:
 
           This section checks for the presence of a Well Architected Review in the AWS account.
         checks:
+          - acm_certificates_expiration_check
           - efs_encryption_at_rest_enabled
           - eks_cluster_kms_cmk_encryption_in_secrets_enabled
           - dynamodb_tables_kms_cmk_encryption_enabled
@@ -196,6 +197,7 @@ sections:
 
           This section checks for the presence of a Well Architected Review in the AWS account.
         checks:
+          - acm_certificates_transparency_logs_enabled
           - apigateway_execution_logging_enabled
           - apigateway_restapi_logging_enabled
           - apigatewayv2_api_access_logging_enabled


### PR DESCRIPTION
### **PR Description: ACM Certificate Checks**  

This PR adds two new checks for ACM certificates:  

1️⃣ **`acm_certificates_expiration_check`**:  
- Verifies ACM certificates are not expired or expiring soon (default threshold: 7 days).  
- Marks the check as failed if a certificate is expired or nearing expiration.  

2️⃣ **`acm_certificates_transparency_logs_enabled`**:  
- Ensures Certificate Transparency (CT) logging is enabled for all ACM certificates.  
- Fails the check if CT logging is disabled.  

Both checks include error handling for API failures and invalid certificates.