### PR TITLE
iam_password_policy_minimum_length_14 fix

### DIFF
--- a/library/aws/checks/iam/iam_password_policy_minimum_length_14.py
+++ b/library/aws/checks/iam/iam_password_policy_minimum_length_14.py
@@ -1,33 +1,39 @@
 """
-AUTHOR: Supriyo Bhakat <supriyo.bhakat@comprinno.net>
-DATE: 2024-10-10
+AUTHOR: Sheikh Aafaq Rashid
+EMAIL: aafaq.rashid@comprinno.net
+DATE: 2025-1-31
 """
 
 import boto3
 from tevico.engine.entities.report.check_model import CheckReport, ResourceStatus
 from tevico.engine.entities.check.check import Check
 
-
 class iam_password_policy_minimum_length_14(Check):
     def execute(self, connection: boto3.Session) -> CheckReport:
         report = CheckReport(name=__name__)
-        client = connection.client('iam')
-
-        try:
-            password_policy = client.get_account_password_policy()
-            policy_exists = True
-        except Exception:
-            policy_exists = False
         
-        if policy_exists:
-            password_policy_length = password_policy['PasswordPolicy'].get('MinimumPasswordLength', 0)
-            if password_policy_length >= 14:
-                report.status = ResourceStatus.PASSED
-            else:
-                report.status = ResourceStatus.FAILED
-                
-        else:
+        try:
+            # Create an IAM client using the provided boto3 session
+            client = connection.client('iam')
+            
+            # Fetch the account's IAM password policy
+            account_password_policy = client.get_account_password_policy()
+            password_policy = account_password_policy['PasswordPolicy']
+            
+            # Get the 'MinimumPasswordLength' setting from the password policy
+            minimum_password_length = password_policy.get('MinimumPasswordLength', 0)
+
+            # Check if 'MinimumPasswordLength' is 14 or more, indicating strong password policy
+            report.status = minimum_password_length >= 14
+            report.resource_ids_status['password_policy'] = minimum_password_length >= 14
+
+        except client.exceptions.NoSuchEntityException:
+            # Handle the case where no password policy is found
+            report.status = ResourceStatus.FAILED
+            report.resource_ids_status['password_policy'] = False
+        except Exception:
+            # Handle any other errors
             report.status = ResourceStatus.FAILED
 
-        report.resource_ids_status['IAM Password Policy'] = report.status
+        # Return the generated report
         return report


### PR DESCRIPTION
UserWarning: Pydantic serializer warnings:
  Expected `bool` but got `ResourceStatus` with value `<ResourceStatus.FAILED: 'failed'>` - serialized value may not be as expected
  return self.__[pydantic_serializer__.to](http://pydantic_serializer__.to/)_python(
  
  Fixed the above error