### PR TITLE
updated check status from to Enum for all checks

### DIFF
--- a/library/aws/checks/dynamodb/dynamodb_tables_pitr_enabled.py
+++ b/library/aws/checks/dynamodb/dynamodb_tables_pitr_enabled.py
@@ -12,15 +12,15 @@ class dynamodb_tables_pitr_enabled(Check):
         tables = response['TableNames']
 
         report = CheckReport(name=__name__)
+        report.status = CheckStatus.PASSED
 
         for table in tables:
             response = client.describe_continuous_backups(TableName=table)
             result = response['ContinuousBackupsDescription']['PointInTimeRecoveryDescription']['PointInTimeRecoveryStatus'] == 'ENABLED'
-            if result:
-                status = CheckStatus.PASSED
+            if not result:
+                report.resource_ids_status[table]   = False
+                report.status = CheckStatus.FAILED
             else:
-                status = CheckStatus.FAILED
-            report.status = status
-            report.resource_ids_status[table] = result
+                report.resource_ids_status[table] = True
 
         return report

--- a/library/aws/checks/iam/iam_password_policy_lowercase.py
+++ b/library/aws/checks/iam/iam_password_policy_lowercase.py
@@ -18,6 +18,7 @@ class iam_password_policy_lowercase(Check):
         try:
             password_policy = client.get_account_password_policy()
         except client.exceptions.NoSuchEntityException:
+            report.status = CheckStatus.FAILED
             return report
 
         lowercase_required = password_policy.get('RequireLowercaseCharacters', False)

--- a/library/aws/checks/iam/iam_password_policy_uppercase.py
+++ b/library/aws/checks/iam/iam_password_policy_uppercase.py
@@ -18,6 +18,7 @@ class iam_password_policy_uppercase(Check):
         try:
             password_policy = client.get_account_password_policy()
         except client.exceptions.NoSuchEntityException:
+            report.status = CheckStatus.FAILED
             return report
 
         uppercase_required = password_policy.get('RequireUppercaseCharacters', False)

--- a/library/aws/checks/iam/iam_policy_attached_to_only_group_or_roles.py
+++ b/library/aws/checks/iam/iam_policy_attached_to_only_group_or_roles.py
@@ -5,14 +5,15 @@ DATE: 2024-10-10
 
 
 import boto3
-from tevico.engine.entities.report.check_model import CheckReport
+from tevico.engine.entities.report.check_model import CheckReport, CheckStatus
 from tevico.engine.entities.check.check import Check
 
 class iam_policy_attached_to_only_group_or_roles(Check):
     def execute(self, connection: boto3.Session) -> CheckReport:
         report = CheckReport(name=__name__)
         client = connection.client('iam')
-
+        report.status = CheckStatus.PASSED
+        
         try:
             # List all IAM users
             users = client.list_users()['Users']
@@ -29,13 +30,12 @@ class iam_policy_attached_to_only_group_or_roles(Check):
                 else:
 
                     report.resource_ids_status[username] = False  # No violation
+                    report.status = CheckStatus.FAILED
 
-            # Overall check passes if no user has directly attached policies
-            report.status = not any(report.resource_ids_status.values())
 
         except Exception as e:
 
-            report.status = ResourceStatus.FAILED
+            report.status = CheckStatus.FAILED
 
         return report
 

--- a/library/aws/checks/iam/iam_rotate_access_keys_90_days.py
+++ b/library/aws/checks/iam/iam_rotate_access_keys_90_days.py
@@ -6,12 +6,13 @@ DATE: 2024-10-10
 
 import boto3
 from datetime import datetime, timedelta, timezone
-from tevico.engine.entities.report.check_model import CheckReport
+from tevico.engine.entities.report.check_model import CheckReport, CheckStatus
 from tevico.engine.entities.check.check import Check
 
 class iam_rotate_access_keys_90_days(Check):
     def execute(self, connection: boto3.Session) -> CheckReport:
         report = CheckReport(name=__name__)
+        report.status = CheckStatus.PASSED
         client = connection.client('iam')
 
         try:
@@ -37,12 +38,12 @@ class iam_rotate_access_keys_90_days(Check):
                     else:
 
                         report.resource_ids_status[username] = False
+                        report.status = CheckStatus.FAILED
 
             # Check if any users have access keys older than 90 days
-            report.status = not any(report.resource_ids_status.values())
         except Exception as e:
 
-            report.status = ResourceStatus.FAILED
+            report.status = CheckStatus.FAILED
         
         return report
 

--- a/library/aws/checks/iam/iam_user_mfa_enabled_console_access.py
+++ b/library/aws/checks/iam/iam_user_mfa_enabled_console_access.py
@@ -4,11 +4,12 @@ DATE: 2024-10-10
 """
 
 import boto3
-from tevico.engine.entities.report.check_model import CheckReport
+from tevico.engine.entities.report.check_model import CheckReport, CheckStatus
 from tevico.engine.entities.check.check import Check
 class iam_user_mfa_enabled_console_access(Check):
     def execute(self, connection: boto3.Session) -> CheckReport:
         report = CheckReport(name=__name__)
+        report.status = CheckStatus.PASSED
         client = connection.client('iam')
         try:
             # List all IAM users
@@ -23,10 +24,10 @@ class iam_user_mfa_enabled_console_access(Check):
                 else:
 
                     report.resource_ids_status[username] = False
-            report.status = all(report.resource_ids_status.values())
+                    report.status = CheckStatus.FAILED
         except Exception as e:
 
-            report.status = ResourceStatus.FAILED
+            report.status = CheckStatus.FAILED
         return report
 
 

--- a/library/aws/checks/iam/iam_user_multiple_active_access_keys.py
+++ b/library/aws/checks/iam/iam_user_multiple_active_access_keys.py
@@ -4,12 +4,13 @@ DATE: 2024-10-10
 """
 
 import boto3
-from tevico.engine.entities.report.check_model import CheckReport
+from tevico.engine.entities.report.check_model import CheckReport, CheckStatus
 from tevico.engine.entities.check.check import Check
 
 class iam_user_multiple_active_access_keys(Check):
     def execute(self, connection: boto3.Session) -> CheckReport:
         report = CheckReport(name=__name__)
+        report.status = CheckStatus.PASSED
         client = connection.client('iam')
         try:
             # List all IAM users
@@ -26,9 +27,10 @@ class iam_user_multiple_active_access_keys(Check):
                 else:
 
                     report.resource_ids_status[username] = False
+                    report.status = CheckStatus.FAILED
             
-            report.status = not any(report.resource_ids_status.values())
+            
         except Exception as e:
 
-            report.status = ResourceStatus.FAILED
+            report.status = CheckStatus.FAILED
         return report

--- a/library/aws/checks/networkfirewall/networkfirewall_multi_az_enabled.py
+++ b/library/aws/checks/networkfirewall/networkfirewall_multi_az_enabled.py
@@ -14,6 +14,7 @@ class networkfirewall_multi_az_enabled(Check):
 
     def execute(self, connection: boto3.Session) -> CheckReport:
         report = CheckReport(name=__name__)
+        report.status = CheckStatus.PASSED
         client = connection.client('network-firewall')
         firewalls = client.list_firewalls()['Firewalls']
         
@@ -23,7 +24,6 @@ class networkfirewall_multi_az_enabled(Check):
             subnet_mappings = firewall_details['Firewall']['SubnetMappings']
             
             if len(subnet_mappings) > 1:
-                report.status = CheckStatus.PASSED
                 report.resource_ids_status[firewall_name] = True
             else:
                 report.status = CheckStatus.FAILED

--- a/library/aws/checks/opensearch/opensearch_service_domains_audit_logging_enabled.py
+++ b/library/aws/checks/opensearch/opensearch_service_domains_audit_logging_enabled.py
@@ -14,12 +14,12 @@ class opensearch_service_domains_audit_logging_enabled(Check):
         domain_names = res['DomainNames']
         
         report = CheckReport(name=__name__)
+        report.status = CheckStatus.FAILED
         
         for dn in domain_names:
             domain_name = dn['DomainName']
             res = client.describe_domain(DomainName=domain_name)
             domain = res['DomainStatus']
-            report.status = CheckStatus.FAILED
             report.resource_ids_status[domain_name] = False
             if domain['LogPublishingOptions']['Options']['AUDIT_LOGS']['Enabled']:
                 report.status = CheckStatus.PASSED

--- a/library/aws/checks/opensearch/opensearch_service_domains_cloudwatch_logging_enabled.py
+++ b/library/aws/checks/opensearch/opensearch_service_domains_cloudwatch_logging_enabled.py
@@ -13,6 +13,7 @@ class opensearch_service_domains_cloudwatch_logging_enabled(Check):
         domain_names = res['DomainNames']
         
         report = CheckReport(name=__name__)
+        report.status = CheckStatus.FAILED
         
         log_publishing_options = [
             'INDEX_SLOW_LOGS',
@@ -24,7 +25,7 @@ class opensearch_service_domains_cloudwatch_logging_enabled(Check):
             domain_name = dn['DomainName']
             res = client.describe_domain_config(DomainName=domain_name)
             for log_option in log_publishing_options:
-                report.status = CheckStatus.FAILED
+                
                 report.resource_ids_status[domain_name] = False
                 if res['DomainConfig']['LogPublishingOptions'][log_option]['Enabled']:
                     report.status = CheckStatus.PASSED

--- a/library/aws/checks/securityhub/securityhub_enabled.py
+++ b/library/aws/checks/securityhub/securityhub_enabled.py
@@ -6,13 +6,14 @@ DATE: 2024-11-11
 
 import boto3
 
-from tevico.engine.entities.report.check_model import CheckReport
+from tevico.engine.entities.report.check_model import CheckReport, CheckStatus
 from tevico.engine.entities.check.check import Check
 
 
 class securityhub_enabled(Check):
     def execute(self, connection: boto3.Session) -> CheckReport:
         report = CheckReport(name=__name__)
+        report.status = CheckStatus.PASSED
         securityhub_client = connection.client('securityhub')
 
         regions = connection.client('ec2').describe_regions()['Regions']
@@ -26,8 +27,10 @@ class securityhub_enabled(Check):
                 report.resource_ids_status[region_name] = True
             except regional_securityhub_client.exceptions.ResourceNotFoundException:
                 report.resource_ids_status[region_name] = False
+                report.status = CheckStatus.FAILED
             except regional_securityhub_client.exceptions.InvalidAccessException:
                 report.resource_ids_status[region_name] = False
+                report.status = CheckStatus.FAILED
 
         return report
 

--- a/library/aws/checks/sns/sns_topics_kms_encryption_at_rest_enabled.py
+++ b/library/aws/checks/sns/sns_topics_kms_encryption_at_rest_enabled.py
@@ -4,15 +4,17 @@ EMAIL: supriyo.bhakat@comprinno.net
 DATE: 2024-11-11
 """
 
+import re
 import boto3
 
-from tevico.engine.entities.report.check_model import CheckReport
+from tevico.engine.entities.report.check_model import CheckReport, CheckStatus
 from tevico.engine.entities.check.check import Check
 
 
 class sns_topics_kms_encryption_at_rest_enabled(Check):
     def execute(self, connection: boto3.Session) -> CheckReport:
         report = CheckReport(name=__name__)
+        report.status = CheckStatus.PASSED
         sns_client = connection.client('sns')
 
         topics = sns_client.list_topics()['Topics']
@@ -28,8 +30,10 @@ class sns_topics_kms_encryption_at_rest_enabled(Check):
                     report.resource_ids_status[topic_arn] = True
                 else:
                     report.resource_ids_status[topic_arn] = False
+                    report.status = CheckStatus.FAILED
 
             except sns_client.exceptions.NotFoundException:
                 report.resource_ids_status[topic_arn] = False
+                report.status = CheckStatus.FAILED
 
         return report

--- a/library/aws/checks/ssm/secrets_manager_automatic_rotation_enabled.py
+++ b/library/aws/checks/ssm/secrets_manager_automatic_rotation_enabled.py
@@ -4,17 +4,18 @@ EMAIL: supriyo.bhakat@comprinno.net
 DATE: 2024-11-11
 """
 
+from tabnanny import check
 import boto3
 
-from tevico.engine.entities.report.check_model import CheckReport
+from tevico.engine.entities.report.check_model import CheckReport, CheckStatus
 from tevico.engine.entities.check.check import Check
 
 
 class secrets_manager_automatic_rotation_enabled(Check):
     def execute(self, connection: boto3.Session) -> CheckReport:
         report = CheckReport(name=__name__)
+        report.status = CheckStatus.PASSED
         secretsmanager_client = connection.client('secretsmanager')
-        
         secrets = secretsmanager_client.list_secrets()['SecretList']
         
         for secret in secrets:
@@ -22,5 +23,7 @@ class secrets_manager_automatic_rotation_enabled(Check):
             rotation_enabled = secret.get('RotationEnabled', False)
             
             report.resource_ids_status[secret_id] = rotation_enabled
+            if report.resource_ids_status[secret_id] == False:
+                report.status = CheckStatus.FAILED
 
         return report

--- a/library/aws/checks/vpc/vpc_default_security_group_closed.py
+++ b/library/aws/checks/vpc/vpc_default_security_group_closed.py
@@ -6,7 +6,7 @@ DATE: 2024-11-12
 
 import boto3
 
-from tevico.engine.entities.report.check_model import CheckReport
+from tevico.engine.entities.report.check_model import CheckReport, CheckStatus
 from tevico.engine.entities.check.check import Check
 
 
@@ -15,6 +15,7 @@ class vpc_default_security_group_closed(Check):
 
     def execute(self, connection: boto3.Session) -> CheckReport:
         report = CheckReport(name=__name__)
+        report.status = CheckStatus.PASSED
         ec2_client = connection.client('ec2')
 
         try:
@@ -38,8 +39,9 @@ class vpc_default_security_group_closed(Check):
                 if not all_closed:
                     break
 
-            report.status = all_closed
+            if not all_closed:
+                report.status = CheckStatus.FAILED
         except Exception as e:
-            report.status = ResourceStatus.FAILED
+            report.status = CheckStatus.FAILED
 
         return report


### PR DESCRIPTION


### Description
This PR modifies the `resource.status` for the following 16 checks to ensure that `report.status` is set as an enum instead of a boolean, and also initializes the `report.status` within each check.

1. dynamodb_tables_pitr_enabled
2. iam_password_policy_lowercase
3. iam_password_policy_uppercase
4. iam_policy_attached_to_only_group_or_roles
5. iam_rotate_access_keys_90_days
6. iam_user_mfa_enabled_console_access
7. iam_user_multiple_active_access_keys
8. networkfirewall_multi_az_enabled
9. opensearch_service_domains_audit_logging_enabled
10. opensearch_service_domains_cloudwatch_logging_enabled
11. securityhub_enabled
12. sns_topics_kms_encryption_at_rest_enabled
13. secrets_manager_automatic_rotation_enabled
14. vpc_default_security_group_closed
15. vpc_flowlogs_analyze_logs
16. vpc_flowlogs_enable_logging