### PR TITLE
Checks updated to incorporate framework changes

### DIFF
--- a/library/aws/checks/acm/acm_certificates_transparency_logs_enabled.py
+++ b/library/aws/checks/acm/acm_certificates_transparency_logs_enabled.py
@@ -5,7 +5,7 @@ DATE: 2025-01-09
 """
 
 import boto3
-from tevico.engine.entities.report.check_model import CheckReport, CheckStatus
+from tevico.engine.entities.report.check_model import CheckReport, CheckStatus, AwsResource, GeneralResource, ResourceStatus
 from tevico.engine.entities.check.check import Check
 
 class acm_certificates_transparency_logs_enabled(Check):
@@ -15,7 +15,7 @@ class acm_certificates_transparency_logs_enabled(Check):
         # Initialize report and certificates list
         report = CheckReport(name=__name__)
         report.status = CheckStatus.PASSED
-        report.resource_ids_status = {}
+        report.resource_ids_status = []
 
         try:
             # Initialize ACM client
@@ -41,28 +41,66 @@ class acm_certificates_transparency_logs_enabled(Check):
                             transparency_logging = cert_details.get('Certificate', {}).get('Options', {}).get('CertificateTransparencyLoggingPreference', 'ENABLED')
 
                             if transparency_logging != 'ENABLED':
-                                report.resource_ids_status[f"Certificate {cert_arn} has transparency logging disabled."] = False
+                                report.resource_ids_status.append(
+                                    ResourceStatus(
+                                        resource=AwsResource(arn=cert_arn),
+                                        status=CheckStatus.FAILED,
+                                        summary="Certificate " + cert_arn + " has transparency logging disabled. "
+                                    )
+                                )                                
                                 report.status = CheckStatus.FAILED
                             else:
-                                report.resource_ids_status[f"Certificate {cert_arn} has transparency logging enabled."] = True
+                                report.resource_ids_status.append(
+                                    ResourceStatus(
+                                        resource=AwsResource(arn=cert_arn),
+                                        status=CheckStatus.FAILED,
+                                        summary="Certificate " + cert_arn + " has transparency logging enabled. "
+                                    )
+                                )                                
 
                         except Exception as e:
                             # Handle errors in getting certificate details
-                            report.resource_ids_status[f"Error describing {cert_arn}"] = False
+                            report.resource_ids_status.append(
+                                ResourceStatus(
+                                    resource=AwsResource(arn=cert_arn),
+                                    status=CheckStatus.FAILED,
+                                    summary="Error describing " + cert_arn + "."
+                                )
+                            )                                                            
                             report.status = CheckStatus.FAILED
 
             except Exception as e:
                 # Handle errors in listing certificates
-                report.resource_ids_status["ACM listing error"] = False
+                report.resource_ids_status.append(
+                    ResourceStatus(
+                        resource=GeneralResource(resource=""),
+                        status=CheckStatus.SKIPPED,
+                        summary="ACM listing error.",
+                        exception=e
+                    )
+                )
                 report.status = CheckStatus.FAILED
 
             if not certificates_found:
                 # No certificates found, mark the check as passed
-                report.resource_ids_status["No ACM certificates found"] = True
+                report.resource_ids_status.append(
+                    ResourceStatus(
+                        resource=GeneralResource(resource=""),
+                        status=CheckStatus.SKIPPED,
+                        summary="No ACM certificates found."
+                    )
+                )                
 
         except Exception as e:
             # Handle any unexpected errors
-            report.resource_ids_status["Unexpected error"] = False
+            report.resource_ids_status.append(
+                ResourceStatus(
+                    resource=GeneralResource(resource=""),
+                    status=CheckStatus.FAILED,
+                    summary="Unexpected error.",
+                    exception=e
+                )
+            )                
             report.status = CheckStatus.FAILED
 
         return report

--- a/library/aws/checks/cloudfront/cloudfront_distributions_using_deprecated_ssl_protocols.py
+++ b/library/aws/checks/cloudfront/cloudfront_distributions_using_deprecated_ssl_protocols.py
@@ -5,7 +5,7 @@ DATE: 2025-01-09
 """
 
 import boto3
-from tevico.engine.entities.report.check_model import CheckReport, CheckStatus
+from tevico.engine.entities.report.check_model import CheckReport, CheckStatus, AwsResource, GeneralResource, ResourceStatus
 from tevico.engine.entities.check.check import Check
 
 
@@ -20,7 +20,7 @@ class cloudfront_distributions_using_deprecated_ssl_protocols(Check):
 
         # Initialize report status as 'Passed' unless we find a distribution using deprecated SSL protocols
         report.status = CheckStatus.PASSED
-        report.resource_ids_status = {}
+        report.resource_ids_status = []
 
         try:
             # Initialize pagination
@@ -43,6 +43,8 @@ class cloudfront_distributions_using_deprecated_ssl_protocols(Check):
             # Iterate over distributions to check SSL protocols
             for distribution in distributions:
                 distribution_id = distribution['Id']
+                distribution_arn = distribution['ARN']
+
                 # Fetch the SSL configuration for the distribution
                 viewer_certificate = distribution.get('ViewerCertificate', {})
                 ssl_protocols = viewer_certificate.get('MinimumProtocolVersion')
@@ -50,13 +52,32 @@ class cloudfront_distributions_using_deprecated_ssl_protocols(Check):
 
                 # Check for deprecated SSL protocols (TLSv1, TLSv1.1, SSLv3)
                 if ssl_protocols in ['TLSv1', 'TLSv1.1', 'SSLv3']:
-                    report.resource_ids_status[f"{distribution_id} uses the deprecated SSL protocol {ssl_protocols}."] = False
+                    report.resource_ids_status.append(
+                        ResourceStatus(
+                            resource=AwsResource(arn=distribution_arn),
+                            status=CheckStatus.FAILED,
+                            summary=f"{distribution_id} uses the deprecated SSL protocol {ssl_protocols}."
+                        )
+                    )
                     report.status = CheckStatus.FAILED  # Mark report as 'Failed' if any distribution is using deprecated SSL protocols
                 else:
-                    report.resource_ids_status[f"{distribution_id} uses {ssl_protocols}, not a deprecated SSL protocol."] = True
+                    report.resource_ids_status.append(
+                        ResourceStatus(
+                            resource=AwsResource(arn=distribution_arn),
+                            status=CheckStatus.PASSED,
+                            summary=f"{distribution_id} uses {ssl_protocols}, not a deprecated SSL protocol."
+                        )
+                    )
 
         except Exception as e:
             report.status = CheckStatus.FAILED
-            report.resource_ids_status = {}
+            report.resource_ids_status.append(
+                ResourceStatus(
+                    resource=GeneralResource(resource=""),
+                    status=CheckStatus.FAILED,
+                    summary=f"Error while fetching CloudFront distribution config",
+                    exception=e
+                )
+            )
 
         return report

--- a/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
+++ b/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
@@ -5,7 +5,7 @@ DATE: 10-10-2024
 
 import boto3
 
-from tevico.engine.entities.report.check_model import CheckReport, CheckStatus, ResourceStatus, AwsResource
+from tevico.engine.entities.report.check_model import CheckReport, CheckStatus, ResourceStatus, AwsResource, GeneralResource
 from tevico.engine.entities.check.check import Check
 
 

--- a/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
+++ b/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
@@ -41,7 +41,13 @@ class ec2_instance_managed_by_ssm(Check):
             print("in this place")
             # BT commented report.resource_ids_status['No Instances'] = False  # No instances available
             # resource_status = (resource=AwsResource(arn="arn:aws:iam::865246394951:instance-profile/ssm", status=CheckStatus.FAILED, summary="No instances available"))
-            report.resource_ids_status = [ResourceStatus(resource=AwsResource(arn="arn:aws:iam::865246394951:instance-profile/ssm"), status=CheckStatus.FAILED, summary="No instances available")]
+            report.resource_ids_status.append(
+                    ResourceStatus(
+                        resource=GeneralResource(),
+                        status=CheckStatus.FAILED,
+                        summary="No instances available."
+                    )
+            )
             return report
 
         for instance in instances:

--- a/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
+++ b/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
@@ -37,7 +37,9 @@ class ec2_instance_managed_by_ssm(Check):
         # Check if there are instances
         if not instances:
             report.status = CheckStatus.FAILED
-            report.resource_ids_status['No Instances'] = False  # No instances available
+            print("in this place")
+            # BT commented report.resource_ids_status['No Instances'] = False  # No instances available
+            report.resource_ids_status = [ResourceStatus(resource=AwsResource(arn="", status=CheckStatus.FAILED, summary="No instances available"))]
             return report
 
         for instance in instances:

--- a/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
+++ b/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
@@ -5,7 +5,7 @@ DATE: 10-10-2024
 
 import boto3
 
-from tevico.engine.entities.report.check_model import CheckReport, CheckStatus
+from tevico.engine.entities.report.check_model import CheckReport, CheckStatus, ResourceStatus
 from tevico.engine.entities.check.check import Check
 
 

--- a/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
+++ b/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
@@ -43,7 +43,7 @@ class ec2_instance_managed_by_ssm(Check):
             # resource_status = (resource=AwsResource(arn="arn:aws:iam::865246394951:instance-profile/ssm", status=CheckStatus.FAILED, summary="No instances available"))
             report.resource_ids_status.append(
                     ResourceStatus(
-                        resource=GeneralResource(),
+                        resource=GeneralResource(resource=""),
                         status=CheckStatus.FAILED,
                         summary="No instances available."
                     )

--- a/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
+++ b/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
@@ -39,7 +39,7 @@ class ec2_instance_managed_by_ssm(Check):
             report.status = CheckStatus.FAILED
             print("in this place")
             # BT commented report.resource_ids_status['No Instances'] = False  # No instances available
-            report.resource_ids_status = [ResourceStatus(resource=AwsResource(arn="", status=CheckStatus.FAILED, summary="No instances available"))]
+            report.resource_ids_status = [ResourceStatus(resource=AwsResource(arn="arn:aws:iam::865246394951:instance-profile/ssm", status=CheckStatus.FAILED, summary="No instances available"))]
             return report
 
         for instance in instances:

--- a/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
+++ b/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
@@ -19,6 +19,7 @@ class ec2_instance_managed_by_ssm(Check):
         report = CheckReport(name=__name__)
         report.status = CheckStatus.PASSED  # Assume passed unless we find an unmanaged instance
         report.resource_ids_status = {}
+        resource_status = ResourceStatus(name=__name__)
 
         # Fetch all EC2 instances
         try:
@@ -39,7 +40,9 @@ class ec2_instance_managed_by_ssm(Check):
             report.status = CheckStatus.FAILED
             print("in this place")
             # BT commented report.resource_ids_status['No Instances'] = False  # No instances available
-            report.resource_ids_status = [ResourceStatus(resource=AwsResource(arn="arn:aws:iam::865246394951:instance-profile/ssm", status=CheckStatus.FAILED, summary="No instances available"))]
+            resource_status = (resource=AwsResource(arn="arn:aws:iam::865246394951:instance-profile/ssm", status=CheckStatus.FAILED, summary="No instances available"))
+            # BT modified report.resource_ids_status = [ResourceStatus(resource=AwsResource(arn="arn:aws:iam::865246394951:instance-profile/ssm", status=CheckStatus.FAILED, summary="No instances available"))]
+            report.resource_ids_status = [resource_status]
             return report
 
         for instance in instances:

--- a/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
+++ b/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
@@ -41,7 +41,7 @@ class ec2_instance_managed_by_ssm(Check):
             print("in this place")
             # BT commented report.resource_ids_status['No Instances'] = False  # No instances available
             # resource_status = (resource=AwsResource(arn="arn:aws:iam::865246394951:instance-profile/ssm", status=CheckStatus.FAILED, summary="No instances available"))
-            report.resource_ids_status = [ResourceStatus(resource=AwsResource(arn="arn:aws:iam::865246394951:instance-profile/ssm", status=CheckStatus.FAILED, summary="No instances available"))]
+            report.resource_ids_status = [ResourceStatus(resource=AwsResource(arn="arn:aws:iam::865246394951:instance-profile/ssm"), status=CheckStatus.FAILED, summary="No instances available")]
             return report
 
         for instance in instances:

--- a/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
+++ b/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
@@ -18,8 +18,7 @@ class ec2_instance_managed_by_ssm(Check):
 
         report = CheckReport(name=__name__)
         report.status = CheckStatus.PASSED  # Assume passed unless we find an unmanaged instance
-        report.resource_ids_status = {}
-        resource_status = ResourceStatus(name=__name__)
+        report.resource_ids_status = []
 
         # Fetch all EC2 instances
         try:

--- a/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
+++ b/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
@@ -40,7 +40,7 @@ class ec2_instance_managed_by_ssm(Check):
             report.status = CheckStatus.FAILED
             print("in this place")
             # BT commented report.resource_ids_status['No Instances'] = False  # No instances available
-            resource_status = (resource=AwsResource(arn="arn:aws:iam::865246394951:instance-profile/ssm", status=CheckStatus.FAILED, summary="No instances available"))
+            # resource_status = (resource=AwsResource(arn="arn:aws:iam::865246394951:instance-profile/ssm", status=CheckStatus.FAILED, summary="No instances available"))
             report.resource_ids_status = [ResourceStatus(resource=AwsResource(arn="arn:aws:iam::865246394951:instance-profile/ssm", status=CheckStatus.FAILED, summary="No instances available"))]
             return report
 

--- a/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
+++ b/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
@@ -5,7 +5,7 @@ DATE: 10-10-2024
 
 import boto3
 
-from tevico.engine.entities.report.check_model import CheckReport, CheckStatus, ResourceStatus
+from tevico.engine.entities.report.check_model import CheckReport, CheckStatus, ResourceStatus, AwsResource
 from tevico.engine.entities.check.check import Check
 
 

--- a/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
+++ b/library/aws/checks/ec2/ec2_instance_managed_by_ssm.py
@@ -41,8 +41,7 @@ class ec2_instance_managed_by_ssm(Check):
             print("in this place")
             # BT commented report.resource_ids_status['No Instances'] = False  # No instances available
             resource_status = (resource=AwsResource(arn="arn:aws:iam::865246394951:instance-profile/ssm", status=CheckStatus.FAILED, summary="No instances available"))
-            # BT modified report.resource_ids_status = [ResourceStatus(resource=AwsResource(arn="arn:aws:iam::865246394951:instance-profile/ssm", status=CheckStatus.FAILED, summary="No instances available"))]
-            report.resource_ids_status = [resource_status]
+            report.resource_ids_status = [ResourceStatus(resource=AwsResource(arn="arn:aws:iam::865246394951:instance-profile/ssm", status=CheckStatus.FAILED, summary="No instances available"))]
             return report
 
         for instance in instances:

--- a/tevico/engine/entities/report/check_model.py
+++ b/tevico/engine/entities/report/check_model.py
@@ -142,7 +142,7 @@ class CheckReport(BaseModel):
     def has_failed_resources(self):
         # return any(resource.status == CheckStatus.FAILED for resource in self.resource_ids_status)
         for resource in self.resource_ids_status:
-            print(resource)
+            #print(resource)
             if resource.status == CheckStatus.FAILED:
                 return True
         return False


### PR DESCRIPTION
All the checks are updated to use resource_ids_status as per framework updates. 
Framework is updated to expect resource_ids_status as list [] and not dict {}
Fields like summary cannot be empty if status=CheckStatus.<> is anything other than PASSED. 