### PR TITLE
ec2_network_acl_allow_ingress_tcp_port_22_fix

### DIFF
--- a/library/aws/checks/ec2/ec2_network_acl_allow_ingress_tcp_port_22.py
+++ b/library/aws/checks/ec2/ec2_network_acl_allow_ingress_tcp_port_22.py
@@ -93,7 +93,7 @@ class ec2_network_acl_allow_ingress_tcp_port_22(Check):
                     )
 
         except Exception as e:
-            report.status = CheckStatus.UNKNOWN
+            report.status = CheckStatus.FAILED
             report.resource_ids_status.append(
                 ResourceStatus(
                     resource=GeneralResource(name=""),

--- a/library/aws/checks/ec2/ec2_network_acl_allow_ingress_tcp_port_22.py
+++ b/library/aws/checks/ec2/ec2_network_acl_allow_ingress_tcp_port_22.py
@@ -93,11 +93,11 @@ class ec2_network_acl_allow_ingress_tcp_port_22(Check):
                     )
 
         except Exception as e:
-            report.status = CheckStatus.FAILED
+            report.status = CheckStatus.UNKNOWN
             report.resource_ids_status.append(
                 ResourceStatus(
                     resource=GeneralResource(name=""),
-                    status=CheckStatus.FAILED,
+                    status=CheckStatus.UNKNOWN,
                     summary=f"Error fetching Network ACLs: {str(e)}",
                     exception=str(e)
                 )


### PR DESCRIPTION

### Description
This PR updates the logic for the check ec2_network_acl_allow_ingress_tcp_port_22 to ensure all the resources are checked and updated exception handling.