### PR TITLE
feat: added support to set check status logic within the get_report m…

### DIFF
--- a/tevico/engine/entities/check/check.py
+++ b/tevico/engine/entities/check/check.py
@@ -26,8 +26,8 @@ class Check(ABC):
         # print(f'id = {check_report.check_metadata.check_id}')
         
         # Set the check status based on resource_ids_status
-        if check_report.has_failed_resources():
-            check_report.status = CheckStatus.FAILED
+        check_report.set_report_status()
+
         return check_report
     
     @abstractmethod

--- a/tevico/engine/entities/report/check_model.py
+++ b/tevico/engine/entities/report/check_model.py
@@ -144,11 +144,13 @@ class CheckReport(BaseModel):
     report_metadata: Optional[Dict[str, Any]] = None
     created_on: datetime = datetime.now()
 
-    def has_failed_resources(self):
-        # return any(resource.status == CheckStatus.FAILED for resource in self.resource_ids_status)
-        for resource in self.resource_ids_status:
-            # print(resource)
-            if resource.status == CheckStatus.FAILED:
-                return True
-        return False
+    def set_report_status(self):
+        failed_statuses = {CheckStatus.FAILED, CheckStatus.ERRORED, CheckStatus.UNKNOWN}
+
+        if len(self.resource_ids_status) < 1 and self.status == None:
+            self.status = CheckStatus.UNKNOWN
+        elif any(resource.status in failed_statuses for resource in self.resource_ids_status):
+            self.status = CheckStatus.FAILED
+        else:
+            self.status = CheckStatus.PASSED
 


### PR DESCRIPTION
```
Only possible values for overall status = PASSED or FAILED
Only when all resources have status = (PASSED or SKIPPED or NOT_APPLICABLE), overall status = PASSED
Else overall status = FAILED
For account level and service level checks, overall status to be inferred from resource_ids_status[0] (it is expected to contain only 1 element)
```

@bhupali-tambekar-comprinno - As per your message given above I've implemented the code change. Please verify if this is what is expected. I've attached a screenshot of the execution for your reference.

<img width="224" alt="Screenshot 2025-03-13 at 8 42 09 PM" src="https://github.com/user-attachments/assets/405604e6-22e6-4130-a444-435f20810dca" />
