### PR TITLE
Route53 domains privacy protection enabled Route53 Logic Fix

### DIFF
--- a/library/aws/checks/route53/route53_domains_privacy_protection_enabled.py
+++ b/library/aws/checks/route53/route53_domains_privacy_protection_enabled.py
@@ -1,12 +1,15 @@
 """
-AUTHOR: SUPRIYO BHAKAT
-EMAIL: supriyo.bhakat@comprinno.net
-DATE: 2024-11-10
+AUTHOR: Sheikh Aafaq Rashid
+EMAIL: aafaq.rashid@comprinno.net
+DATE: 2025-03-28
 """
 
 import boto3
+from botocore.exceptions import BotoCoreError, ClientError
 
-from tevico.engine.entities.report.check_model import CheckReport, CheckStatus, AwsResource, GeneralResource, ResourceStatus
+from tevico.engine.entities.report.check_model import (
+    CheckReport, CheckStatus, AwsResource, GeneralResource, ResourceStatus
+)
 from tevico.engine.entities.check.check import Check
 
 
@@ -14,35 +17,96 @@ class route53_domains_privacy_protection_enabled(Check):
 
     def execute(self, connection: boto3.Session) -> CheckReport:
         report = CheckReport(name=__name__)
-        report.status = CheckStatus.PASSED
         report.resource_ids_status = []
 
+        try:
+            # Route53 Domains API is only available in us-east-1
+            route53domains_client = connection.client('route53domains', region_name="us-east-1")
+            
+            # Get all domains
+            domains = []
+            paginator = route53domains_client.get_paginator('list_domains')
+            
+            for page in paginator.paginate():
+                domains.extend(page.get('Domains', []))
+            
+            if not domains:
+                report.status = CheckStatus.NOT_APPLICABLE
+                report.resource_ids_status.append(
+                    ResourceStatus(
+                        resource=GeneralResource(name=""),
+                        status=CheckStatus.NOT_APPLICABLE,
+                        summary="No Route53 domains found."
+                    )
+                )
+                return report
+            
+            # Check privacy protection for each domain
+            for domain_info in domains:
+                print(domain_info)
+                domain_name = domain_info['DomainName']
+                domain_arn = f"arn:aws:route53domains:::{domain_name}"
+                
+                try:
+                    domain_detail = route53domains_client.get_domain_detail(DomainName=domain_name)
+                    
+                    # Check all privacy settings (Admin, Registrant, Tech)
+                    admin_privacy = domain_detail.get('AdminPrivacy', False)
+                    registrant_privacy = domain_detail.get('RegistrantPrivacy', False)
+                    tech_privacy = domain_detail.get('TechPrivacy', False)
+                    
+                    # All privacy settings should be enabled
+                    if admin_privacy and registrant_privacy and tech_privacy:
+                        report.resource_ids_status.append(
+                            ResourceStatus(
+                                resource=AwsResource(arn=domain_arn),
+                                status=CheckStatus.PASSED,
+                                summary=f"Domain {domain_name} has complete privacy protection enabled."
+                            )
+                        )
+                    else:
+                        report.status = CheckStatus.FAILED
+                        
+                        # Create detailed message about which privacy settings are missing
+                        missing_privacy = []
+                        if not admin_privacy:
+                            missing_privacy.append("Admin")
+                        if not registrant_privacy:
+                            missing_privacy.append("Registrant")
+                        if not tech_privacy:
+                            missing_privacy.append("Technical")
+                            
+                        missing_str = ", ".join(missing_privacy)
+                        
+                        report.resource_ids_status.append(
+                            ResourceStatus(
+                                resource=AwsResource(arn=domain_arn),
+                                status=CheckStatus.FAILED,
+                                summary=f"Domain {domain_name} is missing privacy protection for: {missing_str} contact information."
+                            )
+                        )
+                
+                except (BotoCoreError, ClientError) as e:
+                    report.status = CheckStatus.UNKNOWN
+                    report.resource_ids_status.append(
+                        ResourceStatus(
+                            resource=AwsResource(arn=domain_arn),
+                            status=CheckStatus.UNKNOWN,
+                            summary=f"Failed to retrieve privacy settings for domain {domain_name}.",
+                            exception=str(e)
+                        )
+                    )
         
-        route53domains_client = connection.client('route53domains', region_name="us-east-1")        
-       
-        domains = route53domains_client.list_domains()['Domains']
-             
-        for domain_info in domains:
-            domain_name = domain_info['DomainName']
-            domain_detail = route53domains_client.get_domain_detail(DomainName=domain_name)
-
-         
-            if domain_detail.get('AdminPrivacy'):
-                report.resource_ids_status.append(
-                    ResourceStatus(
-                        resource=GeneralResource(name=""),
-                        status=CheckStatus.PASSED,
-                        summary=f"{domain_name} has AdminPrivacy set to True"
-                    )
+        except (BotoCoreError, ClientError) as e:
+            report.status = CheckStatus.UNKNOWN
+            report.resource_ids_status.append(
+                ResourceStatus(
+                    resource=GeneralResource(name=""),
+                    status=CheckStatus.UNKNOWN,
+                    summary="Encountered an error while retrieving Route53 domains.",
+                    exception=str(e)
                 )
-            else:
-                report.resource_ids_status.append(
-                    ResourceStatus(
-                        resource=GeneralResource(name=""),
-                        status=CheckStatus.FAILED,
-                        summary=f"{domain_name} has AdminPrivacy set to False"
-                    )
-                )
-                report.status = CheckStatus.FAILED
+            )
 
         return report
+

--- a/library/aws/checks/route53/route53_domains_privacy_protection_enabled.py
+++ b/library/aws/checks/route53/route53_domains_privacy_protection_enabled.py
@@ -43,7 +43,6 @@ class route53_domains_privacy_protection_enabled(Check):
             
             # Check privacy protection for each domain
             for domain_info in domains:
-                print(domain_info)
                 domain_name = domain_info['DomainName']
                 domain_arn = f"arn:aws:route53domains:::{domain_name}"
                 

--- a/library/aws/checks/route53/route53_domains_privacy_protection_enabled.yaml
+++ b/library/aws/checks/route53/route53_domains_privacy_protection_enabled.yaml
@@ -1,25 +1,36 @@
 Provider: "aws"
 CheckID: "route53_domains_privacy_protection_enabled"
-CheckTitle: "Enable Privacy Protection for a Route53 Domain."
-CheckType: []
+CheckTitle: "Ensure Route53 domains have privacy protection enabled"
+CheckType:
+  - "Security"
+  - "Privacy"
 ServiceName: "route53"
-SubServiceName: ""
-ResourceIdTemplate: ""
+SubServiceName: "domains"
+ResourceIdTemplate: "arn:aws:route53domains:::{domain_name}"
 Severity: medium
-ResourceType: "Other"
-Description: "Enable Privacy Protection for a Route53 Domain."
-Risk: "Without privacy protection enabled, one's personal information is published to the public WHOIS database."
+ResourceType: "AwsRoute53Domain"
+Description: "Ensure all Route53 domains have complete privacy protection enabled for Admin, Registrant, and Technical contacts."
+Risk: "Without privacy protection enabled, personal contact information is published to the public WHOIS database, potentially exposing domain owners to spam, phishing, identity theft, and social engineering attacks."
 RelatedUrl: "https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/domain-privacy-protection.html"
 Remediation:
   Code:
-    CLI: "aws route53domains update-domain-contact-privacy --domain-name domain.com --registrant-privacy"
+    CLI: "aws route53domains update-domain-contact-privacy --domain-name example.com --admin-privacy --registrant-privacy --tech-privacy"
     NativeIaC: ""
-    Other: "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/Route53/privacy-protection.html"
-    Terraform: ""
+    Other: ""
+    Terraform: |
+      resource "aws_route53domains_registered_domain" "example" {
+        domain_name = "example.com"
+        
+        admin_privacy = true
+        registrant_privacy = true
+        tech_privacy = true
+      }
   Recommendation:
-    Text: "Ensure default Privacy is enabled."
+    Text: "Enable privacy protection for all contact types (Admin, Registrant, and Technical) for each Route53 domain. This prevents personal information from being publicly accessible in the WHOIS database."
     Url: "https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/domain-privacy-protection.html"
-Categories: []
+Categories:
+  - "security"
+  - "privacy"
 DependsOn: []
 RelatedTo: []
-Notes: ""
+Notes: "Privacy protection is available for most TLDs but may not be available for all domain extensions. Some country-code TLDs do not support privacy protection due to registry policies."

--- a/library/aws/frameworks/well_architected_review.yaml
+++ b/library/aws/frameworks/well_architected_review.yaml
@@ -85,6 +85,7 @@ sections:
           - eks_cluster_kms_cmk_encryption_in_secrets_enabled
           - dynamodb_tables_kms_cmk_encryption_enabled
           - rds_instance_storage_encrypted
+          - route53_domains_privacy_protection_enabled
           - s3_bucket_default_encryption
           - sns_topics_kms_encryption_at_rest_enabled
           - secrets_manager_automatic_rotation_enabled


### PR DESCRIPTION
### Route53 Domain Security Checks

#### 7. Enhanced Route53 Domains Privacy Protection Check
• Expanded check to verify all privacy settings (Admin, Registrant, and Technical)
• Added detailed reporting of which specific privacy settings are missing
• Implemented pagination for accounts with many domains
• Improved error handling and resource identification
