### PR TITLE
fix: added seperate exception for reteriving vpc and vpc flow logs

### DIFF
--- a/library/aws/checks/vpc/vpc_security_group_port_restriction_check.py
+++ b/library/aws/checks/vpc/vpc_security_group_port_restriction_check.py
@@ -121,7 +121,7 @@ class vpc_security_group_port_restriction_check(Check):
                                     failed_ports.append(str(port))
 
                     # -------------------------------------------------------------------
-                    # Records the Evaluation Result for This Security Group.
+                    # Records the Evaluation Result for this security group.
                     # If a violation is found, mark as FAILED; otherwise, mark as PASSED.
                     # Also updates the overall report status if any group fails.
                     # -------------------------------------------------------------------
@@ -151,7 +151,7 @@ class vpc_security_group_port_restriction_check(Check):
                         )
                 except Exception as e:
                     # -------------------------------------------------------------------
-                    # Handles Exceptions for Individual Security Group Processing.
+                    # Handles exceptions for individual security group processing.
                     # If an error occurs while processing a specific security group,
                     # marks its status as UNKNOWN and record the error details.
                     # -------------------------------------------------------------------
@@ -166,7 +166,7 @@ class vpc_security_group_port_restriction_check(Check):
                     )
         except Exception as e:
             # -------------------------------------------------------------------
-            # Global Exception Handling.
+            # Global exception handling.
             # If an error occurs during the retrieval of security groups,
             # marks the overall check status as UNKNOWN and log the error.
             # -------------------------------------------------------------------


### PR DESCRIPTION
Fix: Added separate exception for retrieving VPC and VPC flow logs.

This addresses the issues encountered when retrieving VPC and VPC flow logs. Previously, the exception handling was generic, which made it difficult to diagnose specific failures during the retrieval process. By adding separate exceptions, we can now provide more precise error messages.
---

fix: updated code with the ports that needs to be restricted.

This updates the vpc_security_group_port_restriction_check to list all restricted ports that are open, rather than stopping after finding the first failure. This change addresses the need for comprehensive visibility into security group misconfigurations.
---



### License

By submitting this pull request, I confirm that my contribution is made under the terms of the **Apache 2.0 license**.
