### PR TITLE
Ec2 elastic ips unassociated

### DIFF
--- a/library/aws/checks/ec2/ec2_elastic_ips_unassociated.py
+++ b/library/aws/checks/ec2/ec2_elastic_ips_unassociated.py
@@ -1,0 +1,76 @@
+"""
+AUTHOR: Ninad Lunge
+EMAIL: ninad.lunge@comprinno.net
+DATE: 2025-05-15
+"""
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+from tevico.engine.entities.report.check_model import (
+    CheckReport, CheckStatus, GeneralResource, ResourceStatus
+)
+from tevico.engine.entities.check.check import Check
+
+
+class ec2_elastic_ips_unassociated(Check):
+
+    def execute(self, connection: boto3.Session) -> CheckReport:
+        report = CheckReport(name=__name__)
+        report.resource_ids_status = []
+
+        try:
+            ec2 = connection.client("ec2")
+            response = ec2.describe_addresses()
+            addresses = response.get("Addresses", [])
+
+            if not addresses:
+                report.status = CheckStatus.NOT_APPLICABLE
+                report.resource_ids_status.append(
+                    ResourceStatus(
+                        resource=GeneralResource(name=""),
+                        status=CheckStatus.NOT_APPLICABLE,
+                        summary="No Elastic IPs allocated in this account."
+                    )
+                )
+                return report
+
+            found_unassociated = False
+
+            for addr in addresses:
+                public_ip = addr.get("PublicIp", "Unknown")
+                allocation_id = addr.get("AllocationId", "Unknown")
+                associated = addr.get("InstanceId") or addr.get("NetworkInterfaceId")
+
+                if not associated:
+                    found_unassociated = True
+                    report.resource_ids_status.append(
+                        ResourceStatus(
+                            resource=GeneralResource(name=allocation_id),
+                            status=CheckStatus.FAILED,
+                            summary=f"EIP {public_ip} is unassociated and may incur charges."
+                        )
+                    )
+                else:
+                    report.resource_ids_status.append(
+                        ResourceStatus(
+                            resource=GeneralResource(name=allocation_id),
+                            status=CheckStatus.PASSED,
+                            summary=f"EIP {public_ip} is associated with a resource."
+                        )
+                    )
+
+            report.status = CheckStatus.FAILED if found_unassociated else CheckStatus.PASSED
+
+        except (BotoCoreError, ClientError) as e:
+            report.status = CheckStatus.UNKNOWN
+            report.resource_ids_status.append(
+                ResourceStatus(
+                    resource=GeneralResource(name=""),
+                    status=CheckStatus.UNKNOWN,
+                    summary="Error retrieving Elastic IPs.",
+                    exception=str(e)
+                )
+            )
+
+        return report

--- a/library/aws/checks/ec2/ec2_elastic_ips_unassociated.yaml
+++ b/library/aws/checks/ec2/ec2_elastic_ips_unassociated.yaml
@@ -1,0 +1,29 @@
+Provider: aws
+CheckID: ec2_elastic_ips_unassociated
+CheckTitle: Detect unassociated Elastic IPs (EIPs)
+CheckType: []
+ServiceName: ec2
+SubServiceName: elastic-ip
+ResourceIdTemplate: arn:aws:ec2:region:account-id:elastic-ip/public-ip
+Severity: medium
+ResourceType: AwsEc2ElasticIp
+Description: Identifies Elastic IP addresses that are not associated with any EC2 instance or network interface and may be incurring unnecessary costs.
+Risk: Unassociated EIPs are charged on a per-hour basis, leading to unnecessary cost if not monitored.
+RelatedUrl: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html
+Remediation:
+  Code:
+    CLI: "aws ec2 release-address --allocation-id <allocation-id>"
+    NativeIaC: ""
+    Other: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html#using-instance-addressing-limit
+    Terraform: |
+      resource "aws_eip" "example" {
+        instance = aws_instance.example.id
+      }
+  Recommendation:
+    Text: Regularly audit Elastic IPs and release those that are unassociated to avoid unnecessary charges.
+    Url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html
+Categories:
+  - Cost Optimization
+DependsOn: []
+RelatedTo: []
+Notes:

--- a/library/aws/frameworks/well_architected_review.yaml
+++ b/library/aws/frameworks/well_architected_review.yaml
@@ -35,6 +35,7 @@ sections:
           - ec2_microsoft_sql_server_end_of_support
           - ssm_managed_compliant_patching
           - ssm_patch_manager_enabled
+          - ec2_elastic_ips_unassociated
 
   - name: Security
     description: |

--- a/library/aws/provider.py
+++ b/library/aws/provider.py
@@ -5,7 +5,6 @@ from typing import Any, Dict
 from tevico.engine.configs.config import ConfigUtils
 from tevico.engine.entities.provider.provider import Provider
 
-
 class AWSProvider(Provider):
     
     __provider_name: str = 'AWS'

--- a/tests/ec2_elastic_ips_unassociated.py
+++ b/tests/ec2_elastic_ips_unassociated.py
@@ -1,0 +1,68 @@
+from botocore.stub import Stubber
+import boto3
+from library.aws.checks.ec2.ec2_elastic_ips_unassociated import ec2_elastic_ips_unassociated
+from tevico.engine.entities.report.check_model import CheckMetadata, Remediation, RemediationCode, RemediationRecommendation
+from tevico.engine.entities.report.check_model import CheckStatus
+
+# Helper to create CheckMetadata
+def build_check_metadata(
+    check_id="ec2_elastic_ips_unassociated",
+    check_title="Elastic IPs should be associated",
+    service_name="EC2"
+) -> CheckMetadata:
+    return CheckMetadata(
+        Provider="aws",
+        CheckID=check_id,
+        CheckTitle=check_title,
+        CheckType=["Security"],
+        ServiceName=service_name,
+        SubServiceName="Elastic IPs",
+        ResourceIdTemplate="{AllocationId}",
+        Severity="Medium",
+        ResourceType="AWS::EC2::EIP",
+        Risk="Unassociated EIPs may incur unnecessary cost.",
+        RelatedUrl="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html",
+        Remediation=Remediation(
+            Code=RemediationCode(CLI="aws ec2 release-address --allocation-id <value>"),
+            Recommendation=RemediationRecommendation(
+                Text="Release unassociated EIPs to avoid charges.",
+                Url="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html"
+            )
+        ),
+        Description="This check identifies unassociated Elastic IPs."
+    )
+
+def test_check_with_mocked_eips():
+    ec2 = boto3.client("ec2", region_name="us-east-1")
+    stubber = Stubber(ec2)
+
+    stubber.add_response(
+        "describe_addresses",
+        {
+            "Addresses": [
+                {
+                    "PublicIp": "1.2.3.4",
+                    "AllocationId": "eipalloc-12345678"
+                    # No InstanceId or NetworkInterfaceId
+                }
+            ]
+        }
+    )
+
+    stubber.activate()
+
+    # Use correct metadata
+    dummy_metadata = build_check_metadata()
+
+    # Patch connection.client to return our stubbed ec2 client
+    class DummySession:
+        def client(self, service_name):
+            return ec2
+
+    check = ec2_elastic_ips_unassociated(metadata=dummy_metadata)
+    report = check.execute(connection=DummySession())
+
+    assert report.status == CheckStatus.FAILED
+    assert len(report.resource_ids_status) == 1
+    assert report.resource_ids_status[0].status == CheckStatus.FAILED
+    assert "unassociated" in report.resource_ids_status[0].summary

--- a/tests/ec2_elastic_ips_unassociated.py
+++ b/tests/ec2_elastic_ips_unassociated.py
@@ -1,10 +1,22 @@
-from botocore.stub import Stubber
-import boto3
-from library.aws.checks.ec2.ec2_elastic_ips_unassociated import ec2_elastic_ips_unassociated
-from tevico.engine.entities.report.check_model import CheckMetadata, Remediation, RemediationCode, RemediationRecommendation
-from tevico.engine.entities.report.check_model import CheckStatus
+"""
+Test suite for the ec2_elastic_ips_unassociated check.
 
-# Helper to create CheckMetadata
+AUTHOR: Ninad Lunge
+EMAIL: ninad.lunge@comprinno.net
+DATE: 2025-05-15
+"""
+
+import boto3
+from botocore.stub import Stubber
+from botocore.exceptions import BotoCoreError
+
+from library.aws.checks.ec2.ec2_elastic_ips_unassociated import ec2_elastic_ips_unassociated
+from tevico.engine.entities.report.check_model import (
+    CheckMetadata, Remediation, RemediationCode, RemediationRecommendation,
+    CheckStatus
+)
+
+# Helper to create CheckMetadata instance
 def build_check_metadata(
     check_id="ec2_elastic_ips_unassociated",
     check_title="Elastic IPs should be associated",
@@ -32,37 +44,133 @@ def build_check_metadata(
         Description="This check identifies unassociated Elastic IPs."
     )
 
-def test_check_with_mocked_eips():
+# Dummy boto3 session wrapper for mocking
+class DummySession:
+    def __init__(self, client):
+        self._client = client
+
+    def client(self, service_name):
+        return self._client
+
+# Test: Unassociated EIP
+def test_check_with_mocked_unassociated_eips():
     ec2 = boto3.client("ec2", region_name="us-east-1")
     stubber = Stubber(ec2)
 
-    stubber.add_response(
-        "describe_addresses",
-        {
-            "Addresses": [
-                {
-                    "PublicIp": "1.2.3.4",
-                    "AllocationId": "eipalloc-12345678"
-                    # No InstanceId or NetworkInterfaceId
-                }
-            ]
-        }
-    )
+    stubber.add_response("describe_addresses", {
+        "Addresses": [
+            {
+                "PublicIp": "1.2.3.4",
+                "AllocationId": "eipalloc-12345678"
+            }
+        ]
+    })
 
     stubber.activate()
 
-    # Use correct metadata
-    dummy_metadata = build_check_metadata()
-
-    # Patch connection.client to return our stubbed ec2 client
-    class DummySession:
-        def client(self, service_name):
-            return ec2
-
-    check = ec2_elastic_ips_unassociated(metadata=dummy_metadata)
-    report = check.execute(connection=DummySession())
+    check = ec2_elastic_ips_unassociated(metadata=build_check_metadata())
+    report = check.execute(connection=DummySession(ec2))
 
     assert report.status == CheckStatus.FAILED
     assert len(report.resource_ids_status) == 1
     assert report.resource_ids_status[0].status == CheckStatus.FAILED
     assert "unassociated" in report.resource_ids_status[0].summary
+
+# Test: No Elastic IPs
+def test_check_with_no_eips():
+    ec2 = boto3.client("ec2", region_name="us-east-1")
+    stubber = Stubber(ec2)
+
+    stubber.add_response("describe_addresses", {"Addresses": []})
+    stubber.activate()
+
+    check = ec2_elastic_ips_unassociated(metadata=build_check_metadata())
+    report = check.execute(connection=DummySession(ec2))
+
+    assert report.status == CheckStatus.NOT_APPLICABLE
+    assert len(report.resource_ids_status) == 1
+    assert report.resource_ids_status[0].status == CheckStatus.NOT_APPLICABLE
+
+# Test: All EIPs associated
+def test_check_with_all_associated_eips():
+    ec2 = boto3.client("ec2", region_name="us-east-1")
+    stubber = Stubber(ec2)
+
+    stubber.add_response("describe_addresses", {
+        "Addresses": [
+            {
+                "PublicIp": "5.6.7.8",
+                "AllocationId": "eipalloc-87654321",
+                "InstanceId": "i-0abcdef1234567890"
+            }
+        ]
+    })
+
+    stubber.activate()
+
+    check = ec2_elastic_ips_unassociated(metadata=build_check_metadata())
+    report = check.execute(connection=DummySession(ec2))
+
+    assert report.status == CheckStatus.PASSED
+    assert report.resource_ids_status[0].status == CheckStatus.PASSED
+
+# Test: Mixed EIPs (some associated, some not)
+def test_check_with_mixed_eips():
+    ec2 = boto3.client("ec2", region_name="us-east-1")
+    stubber = Stubber(ec2)
+
+    stubber.add_response("describe_addresses", {
+        "Addresses": [
+            {
+                "PublicIp": "1.2.3.4",
+                "AllocationId": "eipalloc-unassociated"
+            },
+            {
+                "PublicIp": "5.6.7.8",
+                "AllocationId": "eipalloc-associated",
+                "InstanceId": "i-0abcdef1234567890"
+            }
+        ]
+    })
+
+    stubber.activate()
+
+    check = ec2_elastic_ips_unassociated(metadata=build_check_metadata())
+    report = check.execute(connection=DummySession(ec2))
+
+    assert report.status == CheckStatus.FAILED
+    assert len(report.resource_ids_status) == 2
+    assert any(r.status == CheckStatus.FAILED for r in report.resource_ids_status)
+    assert any(r.status == CheckStatus.PASSED for r in report.resource_ids_status)
+
+# Test: BotoCoreError exception
+def test_check_with_boto_exception():
+    class FailingSession:
+        def client(self, service_name):
+            raise BotoCoreError()
+
+    check = ec2_elastic_ips_unassociated(metadata=build_check_metadata())
+    report = check.execute(connection=FailingSession())
+
+    assert report.status == CheckStatus.UNKNOWN
+    assert len(report.resource_ids_status) == 1
+    assert report.resource_ids_status[0].status == CheckStatus.UNKNOWN
+
+# Test: Missing fields in response
+def test_check_with_missing_fields():
+    ec2 = boto3.client("ec2", region_name="us-east-1")
+    stubber = Stubber(ec2)
+
+    # Missing AllocationId and PublicIp
+    stubber.add_response("describe_addresses", {
+        "Addresses": [{}]
+    })
+
+    stubber.activate()
+
+    check = ec2_elastic_ips_unassociated(metadata=build_check_metadata())
+    report = check.execute(connection=DummySession(ec2))
+
+    assert report.status == CheckStatus.FAILED
+    assert len(report.resource_ids_status) == 1
+    assert "Unknown" in report.resource_ids_status[0].summary

--- a/tests/ec2_elastic_ips_unassociated.py
+++ b/tests/ec2_elastic_ips_unassociated.py
@@ -4,6 +4,7 @@ Test suite for the ec2_elastic_ips_unassociated check.
 AUTHOR: Ninad Lunge
 EMAIL: ninad.lunge@comprinno.net
 DATE: 2025-05-15
+
 """
 
 import boto3
@@ -16,53 +17,62 @@ from tevico.engine.entities.report.check_model import (
     CheckStatus
 )
 
-# Helper to create CheckMetadata instance
+
 def build_check_metadata(
-    check_id="ec2_elastic_ips_unassociated",
-    check_title="Elastic IPs should be associated",
-    service_name="EC2"
+    check_id = "ec2_elastic_ips_unassociated",
+    check_title = "Elastic IPs should be associated",
+    service_name = "EC2"
 ) -> CheckMetadata:
+    """Builds dummy CheckMetadata for testing.
+
+    Args:
+        check_id (str): ID of the check.
+        check_title (str): Title of the check.
+        service_name (str): AWS service name.
+
+    Returns:
+        CheckMetadata: A mock metadata object for test execution.
+    """
     return CheckMetadata(
-        Provider="aws",
-        CheckID=check_id,
-        CheckTitle=check_title,
-        CheckType=["Security"],
-        ServiceName=service_name,
-        SubServiceName="Elastic IPs",
-        ResourceIdTemplate="{AllocationId}",
-        Severity="Medium",
-        ResourceType="AWS::EC2::EIP",
-        Risk="Unassociated EIPs may incur unnecessary cost.",
-        RelatedUrl="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html",
-        Remediation=Remediation(
-            Code=RemediationCode(CLI="aws ec2 release-address --allocation-id <value>"),
-            Recommendation=RemediationRecommendation(
-                Text="Release unassociated EIPs to avoid charges.",
-                Url="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html"
+        Provider = "aws",
+        CheckID = check_id,
+        CheckTitle = check_title,
+        CheckType = ["Security"],
+        ServiceName = service_name,
+        SubServiceName = "Elastic IPs",
+        ResourceIdTemplate = "{AllocationId}",
+        Severity = "Medium",
+        ResourceType = "AWS::EC2::EIP",
+        Risk = "Unassociated EIPs may incur unnecessary cost.",
+        RelatedUrl = "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html",
+        Remediation = Remediation(
+            Code = RemediationCode(CLI="aws ec2 release-address --allocation-id <value>"),
+            Recommendation = RemediationRecommendation(
+                Text = "Release unassociated EIPs to avoid charges.",
+                Url = "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html"
             )
         ),
-        Description="This check identifies unassociated Elastic IPs."
+        Description = "This check identifies unassociated Elastic IPs."
     )
 
-# Dummy boto3 session wrapper for mocking
+
 class DummySession:
+    """Dummy boto3 session wrapper used to inject stubbed EC2 clients into the check."""
     def __init__(self, client):
         self._client = client
 
     def client(self, service_name):
         return self._client
 
-# Test: Unassociated EIP
+
 def test_check_with_mocked_unassociated_eips():
+    """Test that the check flags unassociated Elastic IPs as FAILED."""
     ec2 = boto3.client("ec2", region_name="us-east-1")
     stubber = Stubber(ec2)
 
     stubber.add_response("describe_addresses", {
         "Addresses": [
-            {
-                "PublicIp": "1.2.3.4",
-                "AllocationId": "eipalloc-12345678"
-            }
+            {"PublicIp": "1.2.3.4", "AllocationId": "eipalloc-12345678"}
         ]
     })
 
@@ -76,23 +86,25 @@ def test_check_with_mocked_unassociated_eips():
     assert report.resource_ids_status[0].status == CheckStatus.FAILED
     assert "unassociated" in report.resource_ids_status[0].summary
 
-# Test: No Elastic IPs
+
 def test_check_with_no_eips():
-    ec2 = boto3.client("ec2", region_name="us-east-1")
+    """Test that the check returns NOT_APPLICABLE when no Elastic IPs are allocated."""
+    ec2 = boto3.client("ec2", region_name = "us-east-1")
     stubber = Stubber(ec2)
 
     stubber.add_response("describe_addresses", {"Addresses": []})
     stubber.activate()
 
-    check = ec2_elastic_ips_unassociated(metadata=build_check_metadata())
-    report = check.execute(connection=DummySession(ec2))
+    check = ec2_elastic_ips_unassociated(metadata = build_check_metadata())
+    report = check.execute(connection = DummySession(ec2))
 
     assert report.status == CheckStatus.NOT_APPLICABLE
     assert len(report.resource_ids_status) == 1
     assert report.resource_ids_status[0].status == CheckStatus.NOT_APPLICABLE
 
-# Test: All EIPs associated
+
 def test_check_with_all_associated_eips():
+    """Test that all associated EIPs are marked as PASSED."""
     ec2 = boto3.client("ec2", region_name="us-east-1")
     stubber = Stubber(ec2)
 
@@ -108,23 +120,21 @@ def test_check_with_all_associated_eips():
 
     stubber.activate()
 
-    check = ec2_elastic_ips_unassociated(metadata=build_check_metadata())
-    report = check.execute(connection=DummySession(ec2))
+    check = ec2_elastic_ips_unassociated(metadata = build_check_metadata())
+    report = check.execute(connection = DummySession(ec2))
 
     assert report.status == CheckStatus.PASSED
     assert report.resource_ids_status[0].status == CheckStatus.PASSED
 
-# Test: Mixed EIPs (some associated, some not)
+
 def test_check_with_mixed_eips():
-    ec2 = boto3.client("ec2", region_name="us-east-1")
+    """Test a scenario with both associated and unassociated EIPs."""
+    ec2 = boto3.client("ec2", region_name = "us-east-1")
     stubber = Stubber(ec2)
 
     stubber.add_response("describe_addresses", {
         "Addresses": [
-            {
-                "PublicIp": "1.2.3.4",
-                "AllocationId": "eipalloc-unassociated"
-            },
+            {"PublicIp": "1.2.3.4", "AllocationId": "eipalloc-unassociated"},
             {
                 "PublicIp": "5.6.7.8",
                 "AllocationId": "eipalloc-associated",
@@ -135,41 +145,40 @@ def test_check_with_mixed_eips():
 
     stubber.activate()
 
-    check = ec2_elastic_ips_unassociated(metadata=build_check_metadata())
-    report = check.execute(connection=DummySession(ec2))
+    check = ec2_elastic_ips_unassociated(metadata = build_check_metadata())
+    report = check.execute(connection = DummySession(ec2))
 
     assert report.status == CheckStatus.FAILED
     assert len(report.resource_ids_status) == 2
     assert any(r.status == CheckStatus.FAILED for r in report.resource_ids_status)
     assert any(r.status == CheckStatus.PASSED for r in report.resource_ids_status)
 
-# Test: BotoCoreError exception
+
 def test_check_with_boto_exception():
+    """Test that an AWS client exception results in UNKNOWN check status."""
     class FailingSession:
         def client(self, service_name):
             raise BotoCoreError()
 
-    check = ec2_elastic_ips_unassociated(metadata=build_check_metadata())
-    report = check.execute(connection=FailingSession())
+    check = ec2_elastic_ips_unassociated(metadata = build_check_metadata())
+    report = check.execute(connection = FailingSession())
 
     assert report.status == CheckStatus.UNKNOWN
     assert len(report.resource_ids_status) == 1
     assert report.resource_ids_status[0].status == CheckStatus.UNKNOWN
 
-# Test: Missing fields in response
+
 def test_check_with_missing_fields():
-    ec2 = boto3.client("ec2", region_name="us-east-1")
+    """Test that missing AllocationId or PublicIp fields default to 'Unknown'."""
+    ec2 = boto3.client("ec2", region_name = "us-east-1")
     stubber = Stubber(ec2)
 
-    # Missing AllocationId and PublicIp
-    stubber.add_response("describe_addresses", {
-        "Addresses": [{}]
-    })
-
+    # Response contains an address with missing fields
+    stubber.add_response("describe_addresses", {"Addresses": [{}]})
     stubber.activate()
 
-    check = ec2_elastic_ips_unassociated(metadata=build_check_metadata())
-    report = check.execute(connection=DummySession(ec2))
+    check = ec2_elastic_ips_unassociated(metadata = build_check_metadata())
+    report = check.execute(connection = DummySession(ec2))
 
     assert report.status == CheckStatus.FAILED
     assert len(report.resource_ids_status) == 1


### PR DESCRIPTION
### Context

This PR adds a new check to identify **Unassociated Elastic IPs (EIPs)** in EC2. Unassociated EIPs can incur unnecessary charges if left unused, and this check helps users identify and remediate such scenarios.

---

### Description

* Introduced a new check: `ec2_elastic_ips_unassociated`, which inspects all EIPs in an AWS account and reports if they are associated with any resource.
* Returns `FAILED` status if any unassociated EIP is found.
* Implements proper handling for edge cases (no EIPs, API errors).
* Includes metadata following the framework's `CheckMetadata` structure.
* Added unit tests using `boto3` and `botocore.stub.Stubber` to simulate EC2 API responses.
* The test validates detection of unassociated EIPs and verifies correct report generation.
* Ensures no modification is made to core files like `check_model`.

Dependencies:

* `boto3`, `botocore`, and `pytest` for testing.

---

### Checklist

* **New Checks**:

  * Are there new checks included in this PR? **Yes**

    * If yes, do we need to update permissions for the provider? **No changes required**. The check uses `ec2:DescribeAddresses`, which is commonly included in read-only roles.

* **Testing**:

  * [x] Verify if the new code is covered by tests.

    * Covered by `test_check_with_mocked_eips` using `Stubber`.

* **Documentation**:

  * [x] Confirm that the code is documented following the [[Google Python Style Guide](https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings)](https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings).

    * Docstrings and inline comments are included.

* **Backport**:

  * [ ] Review if backporting is necessary for this change.

    * Not applicable at this time.

---

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the **Apache 2.0 license**.
