### PR TITLE
apigateway_unused_stages

### DIFF
--- a/library/aws/checks/apigateway/apigateway_unused_stages.py
+++ b/library/aws/checks/apigateway/apigateway_unused_stages.py
@@ -108,10 +108,8 @@ class apigateway_unused_stages(Check):
 
             if unused_stages_found:
                 report.status = CheckStatus.FAILED
-                report.message = "One or more unused API Gateway stages found."
             else:
                 report.status = CheckStatus.PASSED
-                report.message = "No unused API Gateway stages found."
 
         except Exception as e:
             report.resource_ids_status.append(
@@ -123,6 +121,5 @@ class apigateway_unused_stages(Check):
                 )
             )
             report.status = CheckStatus.UNKNOWN
-            report.message = "API Gateway listing error."
 
         return report

--- a/library/aws/checks/apigateway/apigateway_unused_stages.py
+++ b/library/aws/checks/apigateway/apigateway_unused_stages.py
@@ -8,7 +8,7 @@ class CheckUnusedStages(Check):
         super().__init__(metadata)
         self.metadata = metadata
 
-    def execute(self):
+    def execute(self, connection=None):
         apigateway = boto3.client('apigateway')
         cloudwatch = boto3.client('cloudwatch')
         unused_stages = []

--- a/library/aws/checks/apigateway/apigateway_unused_stages.py
+++ b/library/aws/checks/apigateway/apigateway_unused_stages.py
@@ -46,3 +46,5 @@ def check_unused_stages():
                 })
 
     return unused_stages
+
+apigateway_unused_stages = check_unused_stages()

--- a/library/aws/checks/apigateway/apigateway_unused_stages.py
+++ b/library/aws/checks/apigateway/apigateway_unused_stages.py
@@ -1,7 +1,7 @@
 """
-AUTHOR: deepak-puri-comprinno
-EMAIL: deepak.puri@comprinno.net
-DATE: 2025-01-13
+AUTHOR: gunjan-katre-comprinno
+EMAIL: gunjan.katre@comprinno.net
+DATE: 2025-05-19
 """
 
 import boto3

--- a/library/aws/checks/apigateway/apigateway_unused_stages.py
+++ b/library/aws/checks/apigateway/apigateway_unused_stages.py
@@ -3,8 +3,9 @@ from tevico.engine.entities.report.check_model import CheckReport, CheckStatus, 
 from tevico.engine.entities.check.check import Check
 from datetime import datetime, timedelta, UTC
 
-class CheckUnusedStages:
+class CheckUnusedStages(Check):
     def __init__(self, metadata):
+        super().__init__(metadata)
         self.metadata = metadata
 
     def execute(self):
@@ -55,5 +56,5 @@ class CheckUnusedStages:
             'message': f"{len(unused_stages)} unused stages found." if unused_stages else "No unused stages found."
         }
 
-# This exposes the class for Tevico to instantiate with metadata
+# Expose class for Tevico
 apigateway_unused_stages = CheckUnusedStages

--- a/library/aws/checks/apigateway/apigateway_unused_stages.py
+++ b/library/aws/checks/apigateway/apigateway_unused_stages.py
@@ -1,4 +1,6 @@
 import boto3
+from tevico.engine.entities.report.check_model import CheckReport, CheckStatus, AwsResource, GeneralResource, ResourceStatus
+from tevico.engine.entities.check.check import Check
 from datetime import datetime, timedelta, UTC
 
 class CheckUnusedStages:

--- a/library/aws/checks/apigateway/apigateway_unused_stages.py
+++ b/library/aws/checks/apigateway/apigateway_unused_stages.py
@@ -1,60 +1,60 @@
 import boto3
+from tevico.engine.entities.report.check_model import CheckReport, CheckStatus, AwsResource, GeneralResource, ResourceStatus
+from tevico.engine.entities.check.check import Check
 from datetime import datetime, timedelta, UTC
-from tevico.engine.entities.report.check_model import CheckReport, CheckStatus, AwsResource
 
-def execute(self, connection=None):
-    apigateway = boto3.client('apigateway')
-    cloudwatch = boto3.client('cloudwatch')
-    unused_stages = []
+class CheckUnusedStages(Check):
+    def __init__(self, metadata):
+        super().__init__(metadata)
+        self.metadata = metadata
 
-    apis = apigateway.get_rest_apis().get('items', [])
+    def execute(self, connection=None):
+        apigateway = boto3.client('apigateway')
+        cloudwatch = boto3.client('cloudwatch')
+        unused_stages = []
 
-    for api in apis:
-        api_id = api['id']
-        api_name = api['name']
-        stages = apigateway.get_stages(restApiId=api_id).get('item', [])
+        # Retrieve all REST APIs
+        apis = apigateway.get_rest_apis().get('items', [])
 
-        for stage in stages:
-            stage_name = stage['stageName']
-            cache_enabled = stage.get('cacheClusterEnabled', False)
+        for api in apis:
+            api_id = api['id']
+            api_name = api['name']
+            stages = apigateway.get_stages(restApiId=api_id).get('item', [])
 
-            metrics = cloudwatch.get_metric_statistics(
-                Namespace='AWS/ApiGateway',
-                MetricName='Count',
-                Dimensions=[
-                    {'Name': 'ApiName', 'Value': api_name},
-                    {'Name': 'Stage', 'Value': stage_name}
-                ],
-                StartTime=datetime.now(UTC) - timedelta(days=30),
-                EndTime=datetime.now(UTC),
-                Period=86400,
-                Statistics=['Sum']
-            )
+            for stage in stages:
+                stage_name = stage['stageName']
+                cache_enabled = stage.get('cacheClusterEnabled', False)
 
-            request_counts = [point['Sum'] for point in metrics.get('Datapoints', [])]
-            total_requests = sum(request_counts)
-
-            if total_requests == 0:
-                unused_stages.append(
-                    AwsResource(
-                        resource_id=api_id,
-                        resource_name=api_name,
-                        resource_type="ApiGateway",
-                        status=CheckStatus.FAIL,
-                        resource_data={
-                            "stage_name": stage_name,
-                            "cache_enabled": cache_enabled
-                        }
-                    )
+                # Retrieve CloudWatch metrics for the stage
+                metrics = cloudwatch.get_metric_statistics(
+                    Namespace='AWS/ApiGateway',
+                    MetricName='Count',
+                    Dimensions=[
+                        {'Name': 'ApiName', 'Value': api_name},
+                        {'Name': 'Stage', 'Value': stage_name}
+                    ],
+                    StartTime=datetime.now(UTC) - timedelta(days=30),
+                    EndTime=datetime.now(UTC),
+                    Period=86400,
+                    Statistics=['Sum']
                 )
 
-    status = CheckStatus.PASS if not unused_stages else CheckStatus.FAIL
-    message = f"{len(unused_stages)} unused stages found." if unused_stages else "No unused stages found."
+                request_counts = [point['Sum'] for point in metrics.get('Datapoints', [])]
+                total_requests = sum(request_counts)
 
-    report = CheckReport(
-        status=status,
-        message=message,
-        resources=unused_stages
-    )
+                if total_requests == 0:
+                    unused_stages.append({
+                        'api_id': api_id,
+                        'api_name': api_name,
+                        'stage_name': stage_name,
+                        'cache_enabled': cache_enabled
+                    })
 
-    return report
+        return {
+            'status': 'PASS' if not unused_stages else 'FAIL',
+            'unused_stages': unused_stages,
+            'message': f"{len(unused_stages)} unused stages found." if unused_stages else "No unused stages found."
+        }
+
+# Expose class for Tevico
+apigateway_unused_stages = CheckUnusedStages

--- a/library/aws/checks/apigateway/apigateway_unused_stages.py
+++ b/library/aws/checks/apigateway/apigateway_unused_stages.py
@@ -1,50 +1,57 @@
 import boto3
 from datetime import datetime, timedelta, UTC
 
-def check_unused_stages():
-    apigateway = boto3.client('apigateway')
-    cloudwatch = boto3.client('cloudwatch')
-    unused_stages = []
+class CheckUnusedStages:
+    def __init__(self, metadata):
+        self.metadata = metadata
 
-    # Retrieve all REST APIs
-    apis = apigateway.get_rest_apis()['items']
+    def execute(self):
+        apigateway = boto3.client('apigateway')
+        cloudwatch = boto3.client('cloudwatch')
+        unused_stages = []
 
-    for api in apis:
-        api_id = api['id']
-        api_name = api['name']
-        stages = apigateway.get_stages(restApiId=api_id)['item']
+        # Retrieve all REST APIs
+        apis = apigateway.get_rest_apis().get('items', [])
 
-        for stage in stages:
-            stage_name = stage['stageName']
-            # Check if caching is enabled
-            cache_enabled = stage.get('cacheClusterEnabled', False)
+        for api in apis:
+            api_id = api['id']
+            api_name = api['name']
+            stages = apigateway.get_stages(restApiId=api_id).get('item', [])
 
-            # Retrieve CloudWatch metrics for the stage
-            metrics = cloudwatch.get_metric_statistics(
-                Namespace='AWS/ApiGateway',
-                MetricName='Count',
-                Dimensions=[
-                    {'Name': 'ApiName', 'Value': api_name},
-                    {'Name': 'Stage', 'Value': stage_name}
-                ],
-                StartTime=datetime.now(UTC) - timedelta(days=30),
-                EndTime=datetime.now(UTC),
-                Period=86400,
-                Statistics=['Sum']
-            )
+            for stage in stages:
+                stage_name = stage['stageName']
+                cache_enabled = stage.get('cacheClusterEnabled', False)
 
-            # Sum the request counts
-            request_counts = [point['Sum'] for point in metrics.get('Datapoints', [])]
-            total_requests = sum(request_counts)
+                # Retrieve CloudWatch metrics for the stage
+                metrics = cloudwatch.get_metric_statistics(
+                    Namespace='AWS/ApiGateway',
+                    MetricName='Count',
+                    Dimensions=[
+                        {'Name': 'ApiName', 'Value': api_name},
+                        {'Name': 'Stage', 'Value': stage_name}
+                    ],
+                    StartTime=datetime.now(UTC) - timedelta(days=30),
+                    EndTime=datetime.now(UTC),
+                    Period=86400,
+                    Statistics=['Sum']
+                )
 
-            if total_requests == 0:
-                unused_stages.append({
-                    'api_id': api_id,
-                    'api_name': api_name,
-                    'stage_name': stage_name,
-                    'cache_enabled': cache_enabled
-                })
+                request_counts = [point['Sum'] for point in metrics.get('Datapoints', [])]
+                total_requests = sum(request_counts)
 
-    return unused_stages
+                if total_requests == 0:
+                    unused_stages.append({
+                        'api_id': api_id,
+                        'api_name': api_name,
+                        'stage_name': stage_name,
+                        'cache_enabled': cache_enabled
+                    })
 
-apigateway_unused_stages = check_unused_stages
+        return {
+            'status': 'PASS' if not unused_stages else 'FAIL',
+            'unused_stages': unused_stages,
+            'message': f"{len(unused_stages)} unused stages found." if unused_stages else "No unused stages found."
+        }
+
+# This exposes the class for Tevico to instantiate with metadata
+apigateway_unused_stages = CheckUnusedStages

--- a/library/aws/checks/apigateway/apigateway_unused_stages.py
+++ b/library/aws/checks/apigateway/apigateway_unused_stages.py
@@ -1,0 +1,48 @@
+import boto3
+from datetime import datetime, timedelta, UTC
+
+def check_unused_stages():
+    apigateway = boto3.client('apigateway')
+    cloudwatch = boto3.client('cloudwatch')
+    unused_stages = []
+
+    # Retrieve all REST APIs
+    apis = apigateway.get_rest_apis()['items']
+
+    for api in apis:
+        api_id = api['id']
+        api_name = api['name']
+        stages = apigateway.get_stages(restApiId=api_id)['item']
+
+        for stage in stages:
+            stage_name = stage['stageName']
+            # Check if caching is enabled
+            cache_enabled = stage.get('cacheClusterEnabled', False)
+
+            # Retrieve CloudWatch metrics for the stage
+            metrics = cloudwatch.get_metric_statistics(
+                Namespace='AWS/ApiGateway',
+                MetricName='Count',
+                Dimensions=[
+                    {'Name': 'ApiName', 'Value': api_name},
+                    {'Name': 'Stage', 'Value': stage_name}
+                ],
+                StartTime=datetime.now(UTC) - timedelta(days=30),
+                EndTime=datetime.now(UTC),
+                Period=86400,
+                Statistics=['Sum']
+            )
+
+            # Sum the request counts
+            request_counts = [point['Sum'] for point in metrics.get('Datapoints', [])]
+            total_requests = sum(request_counts)
+
+            if total_requests == 0:
+                unused_stages.append({
+                    'api_id': api_id,
+                    'api_name': api_name,
+                    'stage_name': stage_name,
+                    'cache_enabled': cache_enabled
+                })
+
+    return unused_stages

--- a/library/aws/checks/apigateway/apigateway_unused_stages.py
+++ b/library/aws/checks/apigateway/apigateway_unused_stages.py
@@ -9,7 +9,6 @@ from tevico.engine.entities.report.check_model import CheckReport, CheckStatus, 
 from tevico.engine.entities.check.check import Check
 from datetime import datetime, timedelta, UTC
 
-
 class apigateway_unused_stages(Check):
 
     def execute(self, connection: boto3.Session) -> CheckReport:

--- a/library/aws/checks/apigateway/apigateway_unused_stages.py
+++ b/library/aws/checks/apigateway/apigateway_unused_stages.py
@@ -1,60 +1,60 @@
 import boto3
-from tevico.engine.entities.report.check_model import CheckReport, CheckStatus, AwsResource, GeneralResource, ResourceStatus
-from tevico.engine.entities.check.check import Check
 from datetime import datetime, timedelta, UTC
+from tevico.engine.entities.report.check_model import CheckReport, CheckStatus, AwsResource
 
-class CheckUnusedStages(Check):
-    def __init__(self, metadata):
-        super().__init__(metadata)
-        self.metadata = metadata
+def execute(self, connection=None):
+    apigateway = boto3.client('apigateway')
+    cloudwatch = boto3.client('cloudwatch')
+    unused_stages = []
 
-    def execute(self, connection=None):
-        apigateway = boto3.client('apigateway')
-        cloudwatch = boto3.client('cloudwatch')
-        unused_stages = []
+    apis = apigateway.get_rest_apis().get('items', [])
 
-        # Retrieve all REST APIs
-        apis = apigateway.get_rest_apis().get('items', [])
+    for api in apis:
+        api_id = api['id']
+        api_name = api['name']
+        stages = apigateway.get_stages(restApiId=api_id).get('item', [])
 
-        for api in apis:
-            api_id = api['id']
-            api_name = api['name']
-            stages = apigateway.get_stages(restApiId=api_id).get('item', [])
+        for stage in stages:
+            stage_name = stage['stageName']
+            cache_enabled = stage.get('cacheClusterEnabled', False)
 
-            for stage in stages:
-                stage_name = stage['stageName']
-                cache_enabled = stage.get('cacheClusterEnabled', False)
+            metrics = cloudwatch.get_metric_statistics(
+                Namespace='AWS/ApiGateway',
+                MetricName='Count',
+                Dimensions=[
+                    {'Name': 'ApiName', 'Value': api_name},
+                    {'Name': 'Stage', 'Value': stage_name}
+                ],
+                StartTime=datetime.now(UTC) - timedelta(days=30),
+                EndTime=datetime.now(UTC),
+                Period=86400,
+                Statistics=['Sum']
+            )
 
-                # Retrieve CloudWatch metrics for the stage
-                metrics = cloudwatch.get_metric_statistics(
-                    Namespace='AWS/ApiGateway',
-                    MetricName='Count',
-                    Dimensions=[
-                        {'Name': 'ApiName', 'Value': api_name},
-                        {'Name': 'Stage', 'Value': stage_name}
-                    ],
-                    StartTime=datetime.now(UTC) - timedelta(days=30),
-                    EndTime=datetime.now(UTC),
-                    Period=86400,
-                    Statistics=['Sum']
+            request_counts = [point['Sum'] for point in metrics.get('Datapoints', [])]
+            total_requests = sum(request_counts)
+
+            if total_requests == 0:
+                unused_stages.append(
+                    AwsResource(
+                        resource_id=api_id,
+                        resource_name=api_name,
+                        resource_type="ApiGateway",
+                        status=CheckStatus.FAIL,
+                        resource_data={
+                            "stage_name": stage_name,
+                            "cache_enabled": cache_enabled
+                        }
+                    )
                 )
 
-                request_counts = [point['Sum'] for point in metrics.get('Datapoints', [])]
-                total_requests = sum(request_counts)
+    status = CheckStatus.PASS if not unused_stages else CheckStatus.FAIL
+    message = f"{len(unused_stages)} unused stages found." if unused_stages else "No unused stages found."
 
-                if total_requests == 0:
-                    unused_stages.append({
-                        'api_id': api_id,
-                        'api_name': api_name,
-                        'stage_name': stage_name,
-                        'cache_enabled': cache_enabled
-                    })
+    report = CheckReport(
+        status=status,
+        message=message,
+        resources=unused_stages
+    )
 
-        return {
-            'status': 'PASS' if not unused_stages else 'FAIL',
-            'unused_stages': unused_stages,
-            'message': f"{len(unused_stages)} unused stages found." if unused_stages else "No unused stages found."
-        }
-
-# Expose class for Tevico
-apigateway_unused_stages = CheckUnusedStages
+    return report

--- a/library/aws/checks/apigateway/apigateway_unused_stages.py
+++ b/library/aws/checks/apigateway/apigateway_unused_stages.py
@@ -47,4 +47,4 @@ def check_unused_stages():
 
     return unused_stages
 
-apigateway_unused_stages = check_unused_stages()
+apigateway_unused_stages = check_unused_stages

--- a/library/aws/checks/apigateway/apigateway_unused_stages.yaml
+++ b/library/aws/checks/apigateway/apigateway_unused_stages.yaml
@@ -1,0 +1,25 @@
+Provider: aws
+CheckID: apigateway_unused_stages
+CheckTitle: Identify unused Amazon API Gateway REST API stages
+CheckType: [Cost Optimization, Operational Excellence]
+ServiceName: apigateway
+SubServiceName: ""
+ResourceIdTemplate: arn:partition:apigateway:region::/restapis/api-id/stages/stage-name
+Severity: low
+ResourceType: AwsApiGatewayStage
+Description: This check identifies Amazon API Gateway REST API stages that have had no request activity in the past 30 days. These stages may be legacy, unused, or forgotten deployments that contribute to maintenance overhead or additional costs if features like caching are enabled.
+Risk: Leaving unused API Gateway stages deployed can lead to unnecessary CloudWatch log generation, enabled caching costs, and increased attack surface if publicly accessible.
+RelatedUrl: "https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-caching.html"
+Remediation:
+  Code:
+    CLI: aws apigateway delete-stage --rest-api-id <api_id> --stage-name <stage_name>
+    NativeIaC: ""
+    Other: ""
+    Terraform: ""
+  Recommendation:
+    Text: Review API Gateway stages with zero invocations over the past 30 days and remove them if no longer needed.
+    Url: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-stages.html
+Categories: [Cost Optimization, Operational Excellence]
+DependsOn: []
+RelatedTo: []
+Notes: Identifying and removing unused stages improves cost efficiency and infrastructure hygiene.

--- a/library/aws/frameworks/well_architected_review.yaml
+++ b/library/aws/frameworks/well_architected_review.yaml
@@ -35,7 +35,8 @@ sections:
           - ec2_microsoft_sql_server_end_of_support
           - ssm_managed_compliant_patching
           - ssm_patch_manager_enabled
-
+          - apigateway_unused_stages
+          
   - name: Security
     description: |
       The Security pillar includes the ability to protect information, systems, and assets while delivering business

--- a/run.sh
+++ b/run.sh
@@ -10,7 +10,7 @@ rm -rf tevico-community
 branch_name="${1:-"main"}"
 
 echo -ne 'Cloning the repository...\n'
-git clone -b $branch_name https://github.com/comprinnotech/tevico-community.git > /dev/null 2> /dev/null
+git clone -b $branch_name https://github.com/GunjanKatre13/tevico-community.git > /dev/null 2> /dev/null
 cd tevico-community
 
 echo -ne 'Setting up virtual environment...\n'

--- a/run.sh
+++ b/run.sh
@@ -10,7 +10,7 @@ rm -rf tevico-community
 branch_name="${1:-"main"}"
 
 echo -ne 'Cloning the repository...\n'
-git clone -b $branch_name https://github.com/GunjanKatre13/tevico-community.git > /dev/null 2> /dev/null
+git clone -b $branch_name https://github.com/comprinnotech/tevico-community.git > /dev/null 2> /dev/null
 cd tevico-community
 
 echo -ne 'Setting up virtual environment...\n'

--- a/tests/test_apigateway_unused_stages.py
+++ b/tests/test_apigateway_unused_stages.py
@@ -1,104 +1,104 @@
-# import unittest
-# from unittest.mock import patch, MagicMock
-# from library.aws.checks.apigateway.apigateway_unused_stages import check_unused_stages
+import unittest
+from unittest.mock import patch, MagicMock
+from library.aws.checks.apigateway.apigateway_unused_stages import check_unused_stages
 
-# class TestApiGatewayUnusedStages(unittest.TestCase):
+class TestApiGatewayUnusedStages(unittest.TestCase):
 
-#     @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
-#     def test_detects_single_unused_stage(self, mock_boto_client):
-#         mock_apigateway = MagicMock()
-#         mock_cloudwatch = MagicMock()
+    @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
+    def test_detects_single_unused_stage(self, mock_boto_client):
+        mock_apigateway = MagicMock()
+        mock_cloudwatch = MagicMock()
 
-#         def client_side_effect(service_name):
-#             return mock_apigateway if service_name == "apigateway" else mock_cloudwatch
-#         mock_boto_client.side_effect = client_side_effect
+        def client_side_effect(service_name):
+            return mock_apigateway if service_name == "apigateway" else mock_cloudwatch
+        mock_boto_client.side_effect = client_side_effect
 
-#         mock_apigateway.get_rest_apis.return_value = {
-#             'items': [{'id': 'api123', 'name': 'UsedAPI'}, {'id': 'api456', 'name': 'UnusedAPI'}]
-#         }
+        mock_apigateway.get_rest_apis.return_value = {
+            'items': [{'id': 'api123', 'name': 'UsedAPI'}, {'id': 'api456', 'name': 'UnusedAPI'}]
+        }
 
-#         def get_stages_side_effect(restApiId):
-#             return {'item': [{'stageName': 'prod', 'cacheClusterEnabled': False}]} if restApiId == 'api123' \
-#                 else {'item': [{'stageName': 'dev', 'cacheClusterEnabled': True}]}
-#         mock_apigateway.get_stages.side_effect = get_stages_side_effect
+        def get_stages_side_effect(restApiId):
+            return {'item': [{'stageName': 'prod', 'cacheClusterEnabled': False}]} if restApiId == 'api123' \
+                else {'item': [{'stageName': 'dev', 'cacheClusterEnabled': True}]}
+        mock_apigateway.get_stages.side_effect = get_stages_side_effect
 
-#         def metric_stats_side_effect(Namespace, MetricName, Dimensions, StartTime, EndTime, Period, Statistics):
-#             return {'Datapoints': [{'Sum': 15.0}]} if Dimensions[0]['Value'] == 'UsedAPI' else {'Datapoints': []}
-#         mock_cloudwatch.get_metric_statistics.side_effect = metric_stats_side_effect
+        def metric_stats_side_effect(Namespace, MetricName, Dimensions, StartTime, EndTime, Period, Statistics):
+            return {'Datapoints': [{'Sum': 15.0}]} if Dimensions[0]['Value'] == 'UsedAPI' else {'Datapoints': []}
+        mock_cloudwatch.get_metric_statistics.side_effect = metric_stats_side_effect
 
-#         result = check_unused_stages()
+        result = check_unused_stages()
 
-#         self.assertEqual(len(result), 1)
-#         self.assertEqual(result[0]['api_id'], 'api456')
-#         self.assertEqual(result[0]['stage_name'], 'dev')
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['api_id'], 'api456')
+        self.assertEqual(result[0]['stage_name'], 'dev')
 
-#     @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
-#     def test_no_apis_exist(self, mock_boto_client):
-#         mock_apigateway = MagicMock()
-#         mock_cloudwatch = MagicMock()
-#         mock_boto_client.side_effect = lambda s: mock_apigateway if s == "apigateway" else mock_cloudwatch
+    @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
+    def test_no_apis_exist(self, mock_boto_client):
+        mock_apigateway = MagicMock()
+        mock_cloudwatch = MagicMock()
+        mock_boto_client.side_effect = lambda s: mock_apigateway if s == "apigateway" else mock_cloudwatch
 
-#         mock_apigateway.get_rest_apis.return_value = {'items': []}
+        mock_apigateway.get_rest_apis.return_value = {'items': []}
 
-#         result = check_unused_stages()
-#         self.assertEqual(result, [])
+        result = check_unused_stages()
+        self.assertEqual(result, [])
 
-#     @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
-#     def test_api_with_no_stages(self, mock_boto_client):
-#         mock_apigateway = MagicMock()
-#         mock_cloudwatch = MagicMock()
-#         mock_boto_client.side_effect = lambda s: mock_apigateway if s == "apigateway" else mock_cloudwatch
+    @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
+    def test_api_with_no_stages(self, mock_boto_client):
+        mock_apigateway = MagicMock()
+        mock_cloudwatch = MagicMock()
+        mock_boto_client.side_effect = lambda s: mock_apigateway if s == "apigateway" else mock_cloudwatch
 
-#         mock_apigateway.get_rest_apis.return_value = {
-#             'items': [{'id': 'api123', 'name': 'LonelyAPI'}]
-#         }
-#         mock_apigateway.get_stages.return_value = {'item': []}
+        mock_apigateway.get_rest_apis.return_value = {
+            'items': [{'id': 'api123', 'name': 'LonelyAPI'}]
+        }
+        mock_apigateway.get_stages.return_value = {'item': []}
 
-#         result = check_unused_stages()
-#         self.assertEqual(result, [])
+        result = check_unused_stages()
+        self.assertEqual(result, [])
 
-#     @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
-#     def test_missing_metrics(self, mock_boto_client):
-#         mock_apigateway = MagicMock()
-#         mock_cloudwatch = MagicMock()
-#         mock_boto_client.side_effect = lambda s: mock_apigateway if s == "apigateway" else mock_cloudwatch
+    @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
+    def test_missing_metrics(self, mock_boto_client):
+        mock_apigateway = MagicMock()
+        mock_cloudwatch = MagicMock()
+        mock_boto_client.side_effect = lambda s: mock_apigateway if s == "apigateway" else mock_cloudwatch
 
-#         mock_apigateway.get_rest_apis.return_value = {
-#             'items': [{'id': 'api789', 'name': 'BrokenAPI'}]
-#         }
-#         mock_apigateway.get_stages.return_value = {
-#             'item': [{'stageName': 'qa', 'cacheClusterEnabled': False}]
-#         }
-#         mock_cloudwatch.get_metric_statistics.return_value = {}  # Malformed/no 'Datapoints'
+        mock_apigateway.get_rest_apis.return_value = {
+            'items': [{'id': 'api789', 'name': 'BrokenAPI'}]
+        }
+        mock_apigateway.get_stages.return_value = {
+            'item': [{'stageName': 'qa', 'cacheClusterEnabled': False}]
+        }
+        mock_cloudwatch.get_metric_statistics.return_value = {}  # Malformed/no 'Datapoints'
 
-#         result = check_unused_stages()
-#         self.assertEqual(len(result), 1)
-#         self.assertEqual(result[0]['api_id'], 'api789')
-#         self.assertEqual(result[0]['stage_name'], 'qa')
+        result = check_unused_stages()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['api_id'], 'api789')
+        self.assertEqual(result[0]['stage_name'], 'qa')
 
-#     @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
-#     def test_multiple_unused_stages(self, mock_boto_client):
-#         mock_apigateway = MagicMock()
-#         mock_cloudwatch = MagicMock()
-#         mock_boto_client.side_effect = lambda s: mock_apigateway if s == "apigateway" else mock_cloudwatch
+    @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
+    def test_multiple_unused_stages(self, mock_boto_client):
+        mock_apigateway = MagicMock()
+        mock_cloudwatch = MagicMock()
+        mock_boto_client.side_effect = lambda s: mock_apigateway if s == "apigateway" else mock_cloudwatch
 
-#         mock_apigateway.get_rest_apis.return_value = {
-#             'items': [
-#                 {'id': 'api111', 'name': 'API1'},
-#                 {'id': 'api222', 'name': 'API2'}
-#             ]
-#         }
+        mock_apigateway.get_rest_apis.return_value = {
+            'items': [
+                {'id': 'api111', 'name': 'API1'},
+                {'id': 'api222', 'name': 'API2'}
+            ]
+        }
 
-#         def get_stages_side_effect(restApiId):
-#             return {'item': [{'stageName': 'alpha', 'cacheClusterEnabled': False}]} if restApiId == 'api111' \
-#                 else {'item': [{'stageName': 'beta', 'cacheClusterEnabled': False}]}
-#         mock_apigateway.get_stages.side_effect = get_stages_side_effect
+        def get_stages_side_effect(restApiId):
+            return {'item': [{'stageName': 'alpha', 'cacheClusterEnabled': False}]} if restApiId == 'api111' \
+                else {'item': [{'stageName': 'beta', 'cacheClusterEnabled': False}]}
+        mock_apigateway.get_stages.side_effect = get_stages_side_effect
 
-#         mock_cloudwatch.get_metric_statistics.return_value = {'Datapoints': []}
+        mock_cloudwatch.get_metric_statistics.return_value = {'Datapoints': []}
 
-#         result = check_unused_stages()
-#         self.assertEqual(len(result), 2)
-#         self.assertEqual({r['stage_name'] for r in result}, {'alpha', 'beta'})
+        result = check_unused_stages()
+        self.assertEqual(len(result), 2)
+        self.assertEqual({r['stage_name'] for r in result}, {'alpha', 'beta'})
 
-# if __name__ == "__main__":
-#     unittest.main()
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_apigateway_unused_stages.py
+++ b/tests/test_apigateway_unused_stages.py
@@ -1,104 +1,104 @@
-import unittest
-from unittest.mock import patch, MagicMock
-from library.aws.checks.apigateway.apigateway_unused_stages import check_unused_stages
+# import unittest
+# from unittest.mock import patch, MagicMock
+# from library.aws.checks.apigateway.apigateway_unused_stages import check_unused_stages
 
-class TestApiGatewayUnusedStages(unittest.TestCase):
+# class TestApiGatewayUnusedStages(unittest.TestCase):
 
-    @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
-    def test_detects_single_unused_stage(self, mock_boto_client):
-        mock_apigateway = MagicMock()
-        mock_cloudwatch = MagicMock()
+#     @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
+#     def test_detects_single_unused_stage(self, mock_boto_client):
+#         mock_apigateway = MagicMock()
+#         mock_cloudwatch = MagicMock()
 
-        def client_side_effect(service_name):
-            return mock_apigateway if service_name == "apigateway" else mock_cloudwatch
-        mock_boto_client.side_effect = client_side_effect
+#         def client_side_effect(service_name):
+#             return mock_apigateway if service_name == "apigateway" else mock_cloudwatch
+#         mock_boto_client.side_effect = client_side_effect
 
-        mock_apigateway.get_rest_apis.return_value = {
-            'items': [{'id': 'api123', 'name': 'UsedAPI'}, {'id': 'api456', 'name': 'UnusedAPI'}]
-        }
+#         mock_apigateway.get_rest_apis.return_value = {
+#             'items': [{'id': 'api123', 'name': 'UsedAPI'}, {'id': 'api456', 'name': 'UnusedAPI'}]
+#         }
 
-        def get_stages_side_effect(restApiId):
-            return {'item': [{'stageName': 'prod', 'cacheClusterEnabled': False}]} if restApiId == 'api123' \
-                else {'item': [{'stageName': 'dev', 'cacheClusterEnabled': True}]}
-        mock_apigateway.get_stages.side_effect = get_stages_side_effect
+#         def get_stages_side_effect(restApiId):
+#             return {'item': [{'stageName': 'prod', 'cacheClusterEnabled': False}]} if restApiId == 'api123' \
+#                 else {'item': [{'stageName': 'dev', 'cacheClusterEnabled': True}]}
+#         mock_apigateway.get_stages.side_effect = get_stages_side_effect
 
-        def metric_stats_side_effect(Namespace, MetricName, Dimensions, StartTime, EndTime, Period, Statistics):
-            return {'Datapoints': [{'Sum': 15.0}]} if Dimensions[0]['Value'] == 'UsedAPI' else {'Datapoints': []}
-        mock_cloudwatch.get_metric_statistics.side_effect = metric_stats_side_effect
+#         def metric_stats_side_effect(Namespace, MetricName, Dimensions, StartTime, EndTime, Period, Statistics):
+#             return {'Datapoints': [{'Sum': 15.0}]} if Dimensions[0]['Value'] == 'UsedAPI' else {'Datapoints': []}
+#         mock_cloudwatch.get_metric_statistics.side_effect = metric_stats_side_effect
 
-        result = check_unused_stages()
+#         result = check_unused_stages()
 
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]['api_id'], 'api456')
-        self.assertEqual(result[0]['stage_name'], 'dev')
+#         self.assertEqual(len(result), 1)
+#         self.assertEqual(result[0]['api_id'], 'api456')
+#         self.assertEqual(result[0]['stage_name'], 'dev')
 
-    @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
-    def test_no_apis_exist(self, mock_boto_client):
-        mock_apigateway = MagicMock()
-        mock_cloudwatch = MagicMock()
-        mock_boto_client.side_effect = lambda s: mock_apigateway if s == "apigateway" else mock_cloudwatch
+#     @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
+#     def test_no_apis_exist(self, mock_boto_client):
+#         mock_apigateway = MagicMock()
+#         mock_cloudwatch = MagicMock()
+#         mock_boto_client.side_effect = lambda s: mock_apigateway if s == "apigateway" else mock_cloudwatch
 
-        mock_apigateway.get_rest_apis.return_value = {'items': []}
+#         mock_apigateway.get_rest_apis.return_value = {'items': []}
 
-        result = check_unused_stages()
-        self.assertEqual(result, [])
+#         result = check_unused_stages()
+#         self.assertEqual(result, [])
 
-    @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
-    def test_api_with_no_stages(self, mock_boto_client):
-        mock_apigateway = MagicMock()
-        mock_cloudwatch = MagicMock()
-        mock_boto_client.side_effect = lambda s: mock_apigateway if s == "apigateway" else mock_cloudwatch
+#     @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
+#     def test_api_with_no_stages(self, mock_boto_client):
+#         mock_apigateway = MagicMock()
+#         mock_cloudwatch = MagicMock()
+#         mock_boto_client.side_effect = lambda s: mock_apigateway if s == "apigateway" else mock_cloudwatch
 
-        mock_apigateway.get_rest_apis.return_value = {
-            'items': [{'id': 'api123', 'name': 'LonelyAPI'}]
-        }
-        mock_apigateway.get_stages.return_value = {'item': []}
+#         mock_apigateway.get_rest_apis.return_value = {
+#             'items': [{'id': 'api123', 'name': 'LonelyAPI'}]
+#         }
+#         mock_apigateway.get_stages.return_value = {'item': []}
 
-        result = check_unused_stages()
-        self.assertEqual(result, [])
+#         result = check_unused_stages()
+#         self.assertEqual(result, [])
 
-    @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
-    def test_missing_metrics(self, mock_boto_client):
-        mock_apigateway = MagicMock()
-        mock_cloudwatch = MagicMock()
-        mock_boto_client.side_effect = lambda s: mock_apigateway if s == "apigateway" else mock_cloudwatch
+#     @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
+#     def test_missing_metrics(self, mock_boto_client):
+#         mock_apigateway = MagicMock()
+#         mock_cloudwatch = MagicMock()
+#         mock_boto_client.side_effect = lambda s: mock_apigateway if s == "apigateway" else mock_cloudwatch
 
-        mock_apigateway.get_rest_apis.return_value = {
-            'items': [{'id': 'api789', 'name': 'BrokenAPI'}]
-        }
-        mock_apigateway.get_stages.return_value = {
-            'item': [{'stageName': 'qa', 'cacheClusterEnabled': False}]
-        }
-        mock_cloudwatch.get_metric_statistics.return_value = {}  # Malformed/no 'Datapoints'
+#         mock_apigateway.get_rest_apis.return_value = {
+#             'items': [{'id': 'api789', 'name': 'BrokenAPI'}]
+#         }
+#         mock_apigateway.get_stages.return_value = {
+#             'item': [{'stageName': 'qa', 'cacheClusterEnabled': False}]
+#         }
+#         mock_cloudwatch.get_metric_statistics.return_value = {}  # Malformed/no 'Datapoints'
 
-        result = check_unused_stages()
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]['api_id'], 'api789')
-        self.assertEqual(result[0]['stage_name'], 'qa')
+#         result = check_unused_stages()
+#         self.assertEqual(len(result), 1)
+#         self.assertEqual(result[0]['api_id'], 'api789')
+#         self.assertEqual(result[0]['stage_name'], 'qa')
 
-    @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
-    def test_multiple_unused_stages(self, mock_boto_client):
-        mock_apigateway = MagicMock()
-        mock_cloudwatch = MagicMock()
-        mock_boto_client.side_effect = lambda s: mock_apigateway if s == "apigateway" else mock_cloudwatch
+#     @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
+#     def test_multiple_unused_stages(self, mock_boto_client):
+#         mock_apigateway = MagicMock()
+#         mock_cloudwatch = MagicMock()
+#         mock_boto_client.side_effect = lambda s: mock_apigateway if s == "apigateway" else mock_cloudwatch
 
-        mock_apigateway.get_rest_apis.return_value = {
-            'items': [
-                {'id': 'api111', 'name': 'API1'},
-                {'id': 'api222', 'name': 'API2'}
-            ]
-        }
+#         mock_apigateway.get_rest_apis.return_value = {
+#             'items': [
+#                 {'id': 'api111', 'name': 'API1'},
+#                 {'id': 'api222', 'name': 'API2'}
+#             ]
+#         }
 
-        def get_stages_side_effect(restApiId):
-            return {'item': [{'stageName': 'alpha', 'cacheClusterEnabled': False}]} if restApiId == 'api111' \
-                else {'item': [{'stageName': 'beta', 'cacheClusterEnabled': False}]}
-        mock_apigateway.get_stages.side_effect = get_stages_side_effect
+#         def get_stages_side_effect(restApiId):
+#             return {'item': [{'stageName': 'alpha', 'cacheClusterEnabled': False}]} if restApiId == 'api111' \
+#                 else {'item': [{'stageName': 'beta', 'cacheClusterEnabled': False}]}
+#         mock_apigateway.get_stages.side_effect = get_stages_side_effect
 
-        mock_cloudwatch.get_metric_statistics.return_value = {'Datapoints': []}
+#         mock_cloudwatch.get_metric_statistics.return_value = {'Datapoints': []}
 
-        result = check_unused_stages()
-        self.assertEqual(len(result), 2)
-        self.assertEqual({r['stage_name'] for r in result}, {'alpha', 'beta'})
+#         result = check_unused_stages()
+#         self.assertEqual(len(result), 2)
+#         self.assertEqual({r['stage_name'] for r in result}, {'alpha', 'beta'})
 
-if __name__ == "__main__":
-    unittest.main()
+# if __name__ == "__main__":
+#     unittest.main()

--- a/tests/test_apigateway_unused_stages.py
+++ b/tests/test_apigateway_unused_stages.py
@@ -1,0 +1,104 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from library.aws.checks.apigateway.apigateway_unused_stages import check_unused_stages
+
+class TestApiGatewayUnusedStages(unittest.TestCase):
+
+    @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
+    def test_detects_single_unused_stage(self, mock_boto_client):
+        mock_apigateway = MagicMock()
+        mock_cloudwatch = MagicMock()
+
+        def client_side_effect(service_name):
+            return mock_apigateway if service_name == "apigateway" else mock_cloudwatch
+        mock_boto_client.side_effect = client_side_effect
+
+        mock_apigateway.get_rest_apis.return_value = {
+            'items': [{'id': 'api123', 'name': 'UsedAPI'}, {'id': 'api456', 'name': 'UnusedAPI'}]
+        }
+
+        def get_stages_side_effect(restApiId):
+            return {'item': [{'stageName': 'prod', 'cacheClusterEnabled': False}]} if restApiId == 'api123' \
+                else {'item': [{'stageName': 'dev', 'cacheClusterEnabled': True}]}
+        mock_apigateway.get_stages.side_effect = get_stages_side_effect
+
+        def metric_stats_side_effect(Namespace, MetricName, Dimensions, StartTime, EndTime, Period, Statistics):
+            return {'Datapoints': [{'Sum': 15.0}]} if Dimensions[0]['Value'] == 'UsedAPI' else {'Datapoints': []}
+        mock_cloudwatch.get_metric_statistics.side_effect = metric_stats_side_effect
+
+        result = check_unused_stages()
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['api_id'], 'api456')
+        self.assertEqual(result[0]['stage_name'], 'dev')
+
+    @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
+    def test_no_apis_exist(self, mock_boto_client):
+        mock_apigateway = MagicMock()
+        mock_cloudwatch = MagicMock()
+        mock_boto_client.side_effect = lambda s: mock_apigateway if s == "apigateway" else mock_cloudwatch
+
+        mock_apigateway.get_rest_apis.return_value = {'items': []}
+
+        result = check_unused_stages()
+        self.assertEqual(result, [])
+
+    @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
+    def test_api_with_no_stages(self, mock_boto_client):
+        mock_apigateway = MagicMock()
+        mock_cloudwatch = MagicMock()
+        mock_boto_client.side_effect = lambda s: mock_apigateway if s == "apigateway" else mock_cloudwatch
+
+        mock_apigateway.get_rest_apis.return_value = {
+            'items': [{'id': 'api123', 'name': 'LonelyAPI'}]
+        }
+        mock_apigateway.get_stages.return_value = {'item': []}
+
+        result = check_unused_stages()
+        self.assertEqual(result, [])
+
+    @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
+    def test_missing_metrics(self, mock_boto_client):
+        mock_apigateway = MagicMock()
+        mock_cloudwatch = MagicMock()
+        mock_boto_client.side_effect = lambda s: mock_apigateway if s == "apigateway" else mock_cloudwatch
+
+        mock_apigateway.get_rest_apis.return_value = {
+            'items': [{'id': 'api789', 'name': 'BrokenAPI'}]
+        }
+        mock_apigateway.get_stages.return_value = {
+            'item': [{'stageName': 'qa', 'cacheClusterEnabled': False}]
+        }
+        mock_cloudwatch.get_metric_statistics.return_value = {}  # Malformed/no 'Datapoints'
+
+        result = check_unused_stages()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['api_id'], 'api789')
+        self.assertEqual(result[0]['stage_name'], 'qa')
+
+    @patch("library.aws.checks.apigateway.apigateway_unused_stages.boto3.client")
+    def test_multiple_unused_stages(self, mock_boto_client):
+        mock_apigateway = MagicMock()
+        mock_cloudwatch = MagicMock()
+        mock_boto_client.side_effect = lambda s: mock_apigateway if s == "apigateway" else mock_cloudwatch
+
+        mock_apigateway.get_rest_apis.return_value = {
+            'items': [
+                {'id': 'api111', 'name': 'API1'},
+                {'id': 'api222', 'name': 'API2'}
+            ]
+        }
+
+        def get_stages_side_effect(restApiId):
+            return {'item': [{'stageName': 'alpha', 'cacheClusterEnabled': False}]} if restApiId == 'api111' \
+                else {'item': [{'stageName': 'beta', 'cacheClusterEnabled': False}]}
+        mock_apigateway.get_stages.side_effect = get_stages_side_effect
+
+        mock_cloudwatch.get_metric_statistics.return_value = {'Datapoints': []}
+
+        result = check_unused_stages()
+        self.assertEqual(len(result), 2)
+        self.assertEqual({r['stage_name'] for r in result}, {'alpha', 'beta'})
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Context

This pull request adds a new check to detect unused API Gateway stages by analyzing CloudWatch metrics for the last 30 days. It helps identify stages that have zero request traffic, which can be safely removed or reviewed for optimization. This improves AWS API Gateway resource management and cost control.

Fixes no existing issue but adds a valuable AWS best practice check for unused API Gateway stages.

---

### Description

* Added `apigateway_unused_stages` check that:

  * Retrieves all REST APIs and their stages.
  * Uses CloudWatch metrics to find stages with zero requests in the past 30 days.
  * Marks unused stages as FAILED and stages with activity as PASSED.
  * Reports skipped APIs without stages.
* Handles pagination of APIs and error cases gracefully.
* Uses standard Tevico reporting conventions with `CheckReport`, `ResourceStatus`, and `CheckStatus`.

No new external dependencies.

---

### Checklist

* **New Checks**:

  * Are there new checks included in this PR? **Yes**

    * No additional permissions changes are required.

* **Testing**:

  * [x] Verify if the new code is covered by tests.

    * Tests are pending and will be added in a subsequent PR.

* **Documentation**:

  * [x] Confirm that the code is documented following the [[Google Python Style Guide](https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings)](https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings).

    * The code includes appropriate comments and docstrings.

* **Backport**:

  * [ ] Review if backporting is necessary for this change.

    * Not applicable.

---

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the **Apache 2.0 license**.
