### PR TITLE
Test case for check iam_account_maintain_current_contact_details

### DIFF
--- a/library/aws/tests/iam/test_iam_account_maintain_current_contact_details.py
+++ b/library/aws/tests/iam/test_iam_account_maintain_current_contact_details.py
@@ -1,0 +1,143 @@
+"""
+Test for IAM account maintain current contact details check.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+from botocore.exceptions import ClientError
+
+from library.aws.checks.iam.iam_account_maintain_current_contact_details import iam_account_maintain_current_contact_details
+from tevico.engine.entities.report.check_model import CheckStatus, CheckMetadata
+from tevico.engine.entities.report.check_model import Remediation, RemediationCode, RemediationRecommendation
+
+
+class TestIamAccountMaintainCurrentContactDetails:
+    """Test cases for IAM account maintain current contact details check."""
+
+    def setup_method(self):
+        """Set up test method."""
+        metadata = CheckMetadata(
+            Provider="aws",
+            CheckID="iam_account_maintain_current_contact_details",
+            CheckTitle="IAM Account Maintains Current Contact Details",
+            CheckType=["security"],
+            ServiceName="iam",
+            SubServiceName="account",
+            ResourceIdTemplate="account",
+            Severity="medium",
+            ResourceType="aws-account",
+            Risk="Missing or outdated contact details could delay communication with AWS during critical events",
+            RelatedUrl="https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-update-contact.html",
+            Remediation=Remediation(
+                Code=RemediationCode(
+                    CLI="aws account update-contact-information --email-address contact@example.com",
+                    Terraform="N/A",
+                    NativeIaC=None,
+                    Other=None
+                ),
+                Recommendation=RemediationRecommendation(
+                    Text="Update AWS account contact details to ensure timely communication.",
+                    Url="https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-update-contact.html"
+                )
+            ),
+            Description="Ensures the AWS account has up-to-date primary contact details.",
+            Categories=["security", "operations"]
+        )
+
+        self.check = iam_account_maintain_current_contact_details(metadata)
+        self.mock_session = MagicMock()
+        self.mock_client = MagicMock()
+        self.mock_session.client.return_value = self.mock_client
+
+        # Simulate the AWS exception structure
+        self.mock_client.exceptions = MagicMock()
+        class ResourceNotFoundException(Exception): pass
+        self.mock_client.exceptions.ResourceNotFoundException = ResourceNotFoundException
+
+    def test_contact_details_present(self):
+        self.mock_client.get_contact_information.return_value = {
+            'ContactInformation': {
+                'FullName': 'John Doe',
+                'AddressLine1': '123 Main St',
+                'PhoneNumber': '+1234567890',
+                'CompanyName': 'ACME Corp',
+                'WebsiteUrl': 'https://acme.example.com'
+            }
+        }
+
+        report = self.check.execute(self.mock_session)
+        summary = report.resource_ids_status[0].summary or ""
+
+        assert report.status == CheckStatus.PASSED
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.PASSED
+        assert "Primary contact details are up-to-date" in summary
+
+    def test_contact_details_missing_required_fields(self):
+        self.mock_client.get_contact_information.return_value = {
+            'ContactInformation': {
+                'FullName': '',
+                'AddressLine1': '',
+                'PhoneNumber': '',
+                'CompanyName': 'ACME Corp',
+                'WebsiteUrl': 'https://acme.example.com'
+            }
+        }
+
+        report = self.check.execute(self.mock_session)
+        summary = report.resource_ids_status[0].summary or ""
+
+        assert report.status == CheckStatus.FAILED
+        assert len(report.resource_ids_status) == 1
+        assert "missing fields" in summary
+
+    def test_contact_details_not_set(self):
+        self.mock_client.get_contact_information.return_value = {
+            'ContactInformation': {}
+        }
+
+        report = self.check.execute(self.mock_session)
+        summary = report.resource_ids_status[0].summary or ""
+
+        assert report.status == CheckStatus.FAILED
+        assert "Primary contact information is NOT set"  in summary
+        
+
+    def test_no_contact_information_key(self):
+        self.mock_client.get_contact_information.return_value = {}
+
+        report = self.check.execute(self.mock_session)
+        summary = report.resource_ids_status[0].summary or ""
+
+        assert report.status == CheckStatus.FAILED
+        assert "Primary contact information is NOT set" in summary
+
+    def test_resource_not_found_exception(self):
+        self.mock_client.get_contact_information.side_effect = self.mock_client.exceptions.ResourceNotFoundException()
+
+        report = self.check.execute(self.mock_session)
+        summary = report.resource_ids_status[0].summary or ""
+
+        assert report.status == CheckStatus.FAILED
+        assert "Primary contact information is NOT set" in summary
+
+    def test_client_error(self):
+        self.mock_client.get_contact_information.side_effect = ClientError(
+            error_response={'Error': {'Code': 'AccessDenied', 'Message': 'You are not authorized'}},
+            operation_name='GetContactInformation'
+        )
+
+        report = self.check.execute(self.mock_session)
+        summary = report.resource_ids_status[0].summary or ""
+
+        assert report.status == CheckStatus.FAILED
+        assert "Failed to retrieve" in summary or "ClientError" in summary
+
+    def test_unexpected_exception(self):
+        self.mock_client.get_contact_information.side_effect = Exception("Unexpected error")
+
+        report = self.check.execute(self.mock_session)
+        summary = report.resource_ids_status[0].summary or ""
+
+        assert report.status == CheckStatus.FAILED
+        assert "unexpected error" in summary.lower()


### PR DESCRIPTION
Context
This PR introduces unit tests for the iam_account_maintain_current_contact_details check, which ensures that an AWS account's primary contact information is properly set and complete. Keeping this data up to date is critical for timely communication from AWS in case of security incidents, billing issues, or operational disruptions.

Description
The test suite covers multiple scenarios to validate the behavior of the check under various account configurations and error conditions:

- Valid contact details present – All required fields are filled, and the check returns PASSED.
- Some required fields missing – Required fields like FullName, AddressLine1, or PhoneNumber are empty; the check returns FAILED.
- Empty or missing contact information – Contact details are either completely missing or the API does not return the expected key, leading to a FAILED check.
-  ResourceNotFoundException raised – Simulates missing contact info, expected to result in FAILED.
- ClientError (e.g., AccessDenied) – Simulates permission issues with the account service; the check fails gracefully.
-  Unexpected exception – Handles and reports unexpected errors (e.g., runtime exceptions), also returns FAILED.


Highlights

- Mocks the AWS account client's get_contact_information method for full test coverage.
- Simulates both standard responses and AWS-specific exception handling.
- Verifies CheckStatus and summary messages in all test outcomes.
- Improves resilience and correctness of the check logic through rigorous validation.


Checklist

-  Tests validate the presence and completeness of required contact fields.
-  All failure conditions (including AWS exceptions) are accounted for.
-  Covers edge cases and malformed responses robustly.
-  Status codes and summary messages are asserted clearly.


License
I confirm that this contribution is made under the terms of the Apache 2.0 license.