### PR TITLE
Added test cases for check ec2_image_builder_enabled

### DIFF
--- a/library/aws/tests/ec2/__init__.py
+++ b/library/aws/tests/ec2/__init__.py
@@ -1,0 +1,3 @@
+"""
+Test package for IAM checks.
+"""

--- a/library/aws/tests/ec2/test_ec2_image_builder_enabled.py
+++ b/library/aws/tests/ec2/test_ec2_image_builder_enabled.py
@@ -1,0 +1,137 @@
+"""
+Test suite for ec2_image_builder_enabled check.
+
+AUTHOR: Ninad Lunge
+EMAIL: ninad.lunge@comprinno.net
+DATE: 05-06-2025
+"""
+
+import pytest
+from unittest.mock import MagicMock
+from botocore.exceptions import ClientError
+
+from tevico.engine.entities.report.check_model import (
+    CheckStatus, CheckMetadata,
+    Remediation, RemediationCode, RemediationRecommendation
+)
+from library.aws.checks.ec2.ec2_image_builder_enabled import ec2_image_builder_enabled
+
+class TestEc2ImageBuilderEnabled:
+    """Test cases for EC2 Image Builder pipeline enabled check."""
+
+    def setup_method(self):
+        """Set up test method with metadata and mock session/client."""
+        metadata = CheckMetadata(
+            Provider="aws",
+            CheckID="ec2_image_builder_enabled",
+            CheckTitle="EC2 Image Builder Pipeline Enabled",
+            CheckType=["security", "compliance"],
+            ServiceName="imagebuilder",
+            SubServiceName="image-pipeline",
+            ResourceIdTemplate="",
+            Severity="medium",
+            ResourceType="ec2-image-builder-pipeline",
+            Risk="No enabled EC2 Image Builder pipelines may lead to unmanaged image creation",
+            RelatedUrl="https://docs.aws.amazon.com/imagebuilder/latest/userguide/what-is-image-builder.html",
+            Remediation=Remediation(
+                Code=RemediationCode(
+                    CLI="aws imagebuilder update-image-pipeline --image-pipeline-arn <value> --status ENABLED",
+                    Terraform='resource "aws_imagebuilder_image_pipeline" "example" {\n  status = "ENABLED"\n}',
+                    NativeIaC=None,
+                    Other=None
+                ),
+                Recommendation=RemediationRecommendation(
+                    Text="Enable at least one EC2 Image Builder pipeline to manage custom images",
+                    Url="https://docs.aws.amazon.com/imagebuilder/latest/userguide/manage-image-pipelines.html"
+                )
+            ),
+            Description="Checks if at least one EC2 Image Builder pipeline is enabled.",
+            Categories=["security", "compliance"]
+        )
+
+        self.check = ec2_image_builder_enabled(metadata)
+        self.mock_session = MagicMock()
+        self.mock_client = MagicMock()
+        self.mock_session.client.return_value = self.mock_client
+
+    def test_enabled_pipeline_found(self):
+        """Test when at least one pipeline is ENABLED."""
+        self.mock_client.list_image_pipelines.side_effect = [
+            {
+                "imagePipelineList": [
+                    {"status": "DISABLED", "name": "pipeline1"},
+                    {"status": "ENABLED", "name": "pipeline2"},
+                ],
+                "nextToken": None
+            }
+        ]
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.PASSED
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.PASSED
+        assert "EC2 Image Builder pipeline is enabled" in (report.resource_ids_status[0].summary or "")
+
+    def test_no_pipelines_found(self):
+        """Test when no image pipelines exist."""
+        self.mock_client.list_image_pipelines.return_value = {
+            "imagePipelineList": [],
+            "nextToken": None
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.FAILED
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.FAILED
+        assert "No EC2 Image Builder pipelines found" in (report.resource_ids_status[0].summary or "")
+
+    def test_no_enabled_pipelines(self):
+        """Test when pipelines exist but none are ENABLED."""
+        self.mock_client.list_image_pipelines.return_value = {
+            "imagePipelineList": [
+                {"status": "DISABLED", "name": "pipeline1"},
+                {"status": "DISABLED", "name": "pipeline2"},
+            ],
+            "nextToken": None
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.FAILED
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.FAILED
+        assert "No EC2 Image Builder pipelines are in ENABLED state" in (report.resource_ids_status[0].summary or "")
+
+    def test_pagination_handling(self):
+        """Test pagination handling in list_image_pipelines."""
+        self.mock_client.list_image_pipelines.side_effect = [
+            {
+                "imagePipelineList": [{"status": "DISABLED", "name": "pipeline1"}],
+                "nextToken": "token1"
+            },
+            {
+                "imagePipelineList": [{"status": "ENABLED", "name": "pipeline2"}],
+                "nextToken": None
+            }
+        ]
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.PASSED
+        assert any(r.summary and "enabled" in r.summary.lower() for r in report.resource_ids_status)
+
+    def test_client_error_handling(self):
+        """Test when client raises a ClientError."""
+        self.mock_client.list_image_pipelines.side_effect = ClientError(
+            {"Error": {"Code": "InternalError", "Message": "Internal service error"}}, 
+            "ListImagePipelines"
+        )
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.UNKNOWN
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.UNKNOWN
+        assert "Error checking EC2 Image Builder pipelines" in (report.resource_ids_status[0].summary or "")


### PR DESCRIPTION
### Context

Implemented test cases for the `ec2_image_builder_enabled` AWS Well-Architected check.
This addition ensures proper validation and coverage of the logic determining whether any EC2 Image Builder pipelines are enabled.
Fixes test coverage gap in `ec2_image_builder_enabled.py`.

### Description

Added a comprehensive test suite for the `ec2_image_builder_enabled` check including the following scenarios:

* At least one pipeline is enabled (positive case)
* No pipelines exist
* Pipelines exist but none are enabled
* Pagination handling with a mix of enabled/disabled pipelines
* ClientError handling from the boto3 client

Each test case validates the returned `CheckReport` status, resource summaries, and exception handling paths.

No additional dependencies were introduced.

### Checklist

* [x] Added new checks? If yes, reviewed necessary permissions — *Not applicable (test-only change)*
* [x] Code covered by tests (if not, explain why)
* [x] Documentation follows [[Google Python Style Guide](https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings)](https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings)
* [x] Considered if backporting is needed — *Not applicable*

### License

I confirm that my contribution is made under the terms of the **Apache 2.0 license**.
