### PR TITLE
Test case for check networkfirewall_logging_enabled

### DIFF
--- a/library/aws/tests/networkfirewall/test_networkfirewall_logging_enabled.py
+++ b/library/aws/tests/networkfirewall/test_networkfirewall_logging_enabled.py
@@ -1,0 +1,109 @@
+import pytest
+from unittest.mock import MagicMock
+from tevico.engine.entities.report.check_model import CheckStatus, CheckMetadata, Remediation, RemediationCode, RemediationRecommendation
+from library.aws.checks.networkfirewall.networkfirewall_logging_enabled import networkfirewall_logging_enabled
+
+
+class TestNetworkFirewallLoggingEnabled:
+
+    def setup_method(self):
+        metadata = CheckMetadata(
+            Provider="aws",
+            CheckID="networkfirewall_logging_enabled",
+            CheckTitle="Ensure Network Firewall logging is enabled",
+            CheckType=["security"],
+            ServiceName="network-firewall",
+            SubServiceName="logging",
+            ResourceIdTemplate="arn:aws:network-firewall:{region}:{account}:firewall/{firewall_name}",
+            Severity="high",
+            ResourceType="AWS::NetworkFirewall::Firewall",
+            Risk="Without logging, traffic going through Network Firewall cannot be monitored or audited.",
+            RelatedUrl="https://docs.aws.amazon.com/network-firewall/latest/developerguide/logging.html",
+            Remediation=Remediation(
+                Code=RemediationCode(
+                    CLI="aws network-firewall update-logging-configuration --firewall-arn <value> --logging-configuration file://logging.json"
+                ),
+                Recommendation=RemediationRecommendation(
+                    Text="Enable logging for all Network Firewall resources.",
+                    Url="https://docs.aws.amazon.com/network-firewall/latest/developerguide/logging.html"
+                ),
+            ),
+            Description="Checks whether logging is enabled for AWS Network Firewall.",
+            Categories=["security", "audit"]
+        )
+        self.check = networkfirewall_logging_enabled(metadata)
+        self.mock_session = MagicMock()
+        self.mock_client = MagicMock()
+        self.mock_session.client.return_value = self.mock_client
+
+    def test_no_firewalls(self):
+        self.mock_client.list_firewalls.return_value = {"Firewalls": []}
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.NOT_APPLICABLE
+        assert report.resource_ids_status[0].status == CheckStatus.NOT_APPLICABLE
+        assert report.resource_ids_status[0].summary == "No Network Firewall resources found."
+
+    def test_firewall_with_logging_enabled(self):
+        self.mock_client.list_firewalls.return_value = {
+            "Firewalls": [{
+                "FirewallName": "fw-enabled",
+                "FirewallArn": "arn:aws:network-firewall:us-east-1:123456789012:firewall/fw-enabled"
+            }]
+        }
+        self.mock_client.describe_logging_configuration.return_value = {
+            "LoggingConfiguration": {
+                "LogDestinationConfigs": [{"LogType": "ALERT", "LogDestinationType": "CloudWatchLogs"}]
+            }
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.PASSED
+        assert report.resource_ids_status[0].status == CheckStatus.PASSED
+        assert report.resource_ids_status[0].summary == "Logging is enabled for Network Firewall fw-enabled."
+
+    def test_firewall_with_logging_disabled(self):
+        self.mock_client.list_firewalls.return_value = {
+            "Firewalls": [{
+                "FirewallName": "fw-disabled",
+                "FirewallArn": "arn:aws:network-firewall:us-east-1:123456789012:firewall/fw-disabled"
+            }]
+        }
+        self.mock_client.describe_logging_configuration.return_value = {
+            "LoggingConfiguration": {
+                "LogDestinationConfigs": []
+            }
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.FAILED
+        assert report.resource_ids_status[0].status == CheckStatus.FAILED
+        assert report.resource_ids_status[0].summary == "Logging is not enabled for Network Firewall fw-disabled."
+
+    def test_firewall_logging_config_error(self):
+        self.mock_client.list_firewalls.return_value = {
+            "Firewalls": [{
+                "FirewallName": "fw-error",
+                "FirewallArn": "arn:aws:network-firewall:us-east-1:123456789012:firewall/fw-error"
+            }]
+        }
+        self.mock_client.describe_logging_configuration.side_effect = Exception("Describe error")
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.UNKNOWN
+        assert report.resource_ids_status[0].status == CheckStatus.UNKNOWN
+        assert report.resource_ids_status[0].summary is not None
+        assert "Error retrieving logging configuration for fw-error." in report.resource_ids_status[0].summary
+
+    def test_list_firewalls_raises_exception(self):
+        self.mock_client.list_firewalls.side_effect = Exception("List error")
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.UNKNOWN
+        assert report.resource_ids_status[0].status == CheckStatus.UNKNOWN
+        assert report.resource_ids_status[0].summary and "Error retrieving firewall list" in report.resource_ids_status[0].summary


### PR DESCRIPTION

### Context

This test suite verifies the correctness of the `networkfirewall_logging_enabled` check, which ensures that AWS Network Firewall resources have logging enabled. Logging is essential for security visibility, incident response, and compliance auditing. Without it, potentially malicious or unauthorized traffic may go unnoticed.

### Description

These test cases cover various scenarios to ensure the check responds appropriately based on the logging state of the firewalls, as well as when errors occur while retrieving data:

- Logging Enabled – Ensures the check returns `PASSED` when a firewall has one or more log destinations configured.
- Logging Disabled – Confirms the check returns `FAILED` when a firewall exists but has no log destinations set.
- No Firewalls – Validates that the check returns `NOT_APPLICABLE` with a clear summary when no firewalls are found in the account.
- Error Fetching Logging Configuration – Simulates an exception during the retrieval of a firewall’s logging configuration, ensuring the check returns `UNKNOWN` with an appropriate error message.
- Error Fetching Firewall List – Validates that unexpected exceptions while listing firewalls also result in a `UNKNOWN` status with an informative message.

### Key Features

* Mocks AWS SDK interactions using `unittest.mock` to simulate different API responses and failures.
* Verifies the accuracy of the `CheckStatus` (`PASSED`, `FAILED`, `NOT_APPLICABLE`, `UNKNOWN`) and the corresponding human-readable summary.
* Emphasizes robustness and resilience of the check logic when handling partial or failed data retrieval from AWS.

### Checklist

* [x] Simulates firewalls with and without logging.
* [x] Covers edge cases such as empty resources and AWS SDK exceptions.
* [x] Ensures clear and actionable summaries for each condition.
* [x] Promotes security best practices by verifying observability for firewall traffic.

### License

This test is provided under the **Apache 2.0 license** and contributes to validating AWS security posture in the Tevico framework.
