### PR TITLE
Test case for check kms_cmk_rotation_enabled

### DIFF
--- a/library/aws/tests/kms/test_kms_cmk_rotation_enabled.py
+++ b/library/aws/tests/kms/test_kms_cmk_rotation_enabled.py
@@ -1,0 +1,177 @@
+import pytest
+from unittest.mock import MagicMock
+from tevico.engine.entities.report.check_model import (
+    CheckStatus,
+    CheckMetadata,
+    Remediation,
+    RemediationCode,
+    RemediationRecommendation,
+)
+from library.aws.checks.kms.kms_cmk_rotation_enabled import kms_cmk_rotation_enabled
+
+
+class TestKMSCMKRotationEnabled:
+
+    def setup_method(self):
+        metadata = CheckMetadata(
+            Provider="aws",
+            CheckID="kms_cmk_rotation_enabled",
+            CheckTitle="Ensure that automatic rotation is enabled for KMS Customer Managed Keys (CMKs)",
+            CheckType=["security", "compliance"],
+            ServiceName="kms",
+            SubServiceName="key",
+            ResourceIdTemplate="",
+            Severity="medium",
+            ResourceType="AWS::KMS::Key",
+            Risk="If rotation is not enabled, the key material may become less secure over time.",
+            RelatedUrl="https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html",
+            Remediation=Remediation(
+                Code=RemediationCode(
+                    CLI="aws kms enable-key-rotation --key-id <key-id>",
+                    Terraform=None,
+                    NativeIaC=None,
+                    Other=None,
+                ),
+                Recommendation=RemediationRecommendation(
+                    Text="Enable automatic rotation of CMKs to enhance security.",
+                    Url="https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html"
+                )
+            ),
+            Description="Checks whether rotation is enabled for customer managed CMKs.",
+            Categories=["encryption", "security", "compliance"]
+        )
+        self.check = kms_cmk_rotation_enabled(metadata)
+        self.mock_session = MagicMock()
+        self.mock_kms_client = MagicMock()
+        self.mock_session.client.return_value = self.mock_kms_client
+
+    def test_rotation_enabled_for_customer_cmk(self):
+        # Mock list_keys response with one key
+        self.mock_kms_client.list_keys.side_effect = [
+            {"Keys": [{"KeyId": "key-123"}], "NextMarker": None}
+        ]
+        # Mock describe_key for enabled customer key
+        self.mock_kms_client.describe_key.return_value = {
+            "KeyMetadata": {
+                "KeyId": "key-123",
+                "Arn": "arn:aws:kms:region:acct:key/key-123",
+                "KeyManager": "CUSTOMER",
+                "KeyState": "Enabled",
+            }
+        }
+        # Mock get_key_rotation_status returning rotation enabled
+        self.mock_kms_client.get_key_rotation_status.return_value = {
+            "KeyRotationEnabled": True
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.PASSED
+        assert any(
+            r.summary and "rotation is enabled" in r.summary.lower()
+            for r in report.resource_ids_status
+        )
+
+    def test_rotation_not_enabled_for_customer_cmk(self):
+        # Mock list_keys response with one key
+        self.mock_kms_client.list_keys.side_effect = [
+            {"Keys": [{"KeyId": "key-456"}], "NextMarker": None}
+        ]
+        # Mock describe_key for enabled customer key
+        self.mock_kms_client.describe_key.return_value = {
+            "KeyMetadata": {
+                "KeyId": "key-456",
+                "Arn": "arn:aws:kms:region:acct:key/key-456",
+                "KeyManager": "CUSTOMER",
+                "KeyState": "Enabled",
+            }
+        }
+        # Mock get_key_rotation_status returning rotation disabled
+        self.mock_kms_client.get_key_rotation_status.return_value = {
+            "KeyRotationEnabled": False
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.FAILED
+        assert any(
+            r.summary and "rotation is not enabled" in r.summary.lower()
+            for r in report.resource_ids_status
+        )
+
+    def test_non_customer_or_disabled_keys_are_ignored(self):
+        # Mock list_keys response with keys that are AWS-managed or disabled
+        self.mock_kms_client.list_keys.side_effect = [
+            {"Keys": [{"KeyId": "key-789"}, {"KeyId": "key-000"}], "NextMarker": None}
+        ]
+        # First key is AWS-managed
+        # Second key is customer but disabled
+        def describe_key_side_effect(KeyId):
+            if KeyId == "key-789":
+                return {
+                    "KeyMetadata": {
+                        "KeyId": "key-789",
+                        "Arn": "arn:aws:kms:region:acct:key/key-789",
+                        "KeyManager": "AWS",
+                        "KeyState": "Enabled",
+                    }
+                }
+            elif KeyId == "key-000":
+                return {
+                    "KeyMetadata": {
+                        "KeyId": "key-000",
+                        "Arn": "arn:aws:kms:region:acct:key/key-000",
+                        "KeyManager": "CUSTOMER",
+                        "KeyState": "Disabled",
+                    }
+                }
+            else:
+                return {}
+
+        self.mock_kms_client.describe_key.side_effect = describe_key_side_effect
+
+        report = self.check.execute(self.mock_session)
+
+        # Since no eligible keys found, report status should be NOT_APPLICABLE or PASSED
+        # But per your original check logic, no eligible keys means NOT_APPLICABLE
+        assert report.status == CheckStatus.NOT_APPLICABLE or report.status == CheckStatus.PASSED
+        # The resource_ids_status should have at least one entry for no customer-managed keys
+        assert any(
+            r.summary and "no customer-managed cmks found" in r.summary.lower()
+            for r in report.resource_ids_status
+        ) or len(report.resource_ids_status) == 0
+
+    def test_error_fetching_keys(self):
+        self.mock_kms_client.list_keys.side_effect = Exception("Simulated API failure")
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.UNKNOWN
+        assert any(
+            r.summary and "error fetching kms keys" in r.summary.lower()
+            for r in report.resource_ids_status
+        )
+
+    def test_error_retrieving_rotation_status(self):
+        self.mock_kms_client.list_keys.side_effect = [
+            {"Keys": [{"KeyId": "key-999"}], "NextMarker": None}
+        ]
+        self.mock_kms_client.describe_key.return_value = {
+            "KeyMetadata": {
+                "KeyId": "key-999",
+                "Arn": "arn:aws:kms:region:acct:key/key-999",
+                "KeyManager": "CUSTOMER",
+                "KeyState": "Enabled",
+            }
+        }
+        self.mock_kms_client.get_key_rotation_status.side_effect = Exception(
+            "Rotation status error"
+        )
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.UNKNOWN
+        assert any(
+            r.summary and "error retrieving rotation status" in r.summary.lower()
+            for r in report.resource_ids_status
+        )

--- a/library/aws/tests/kms/test_kms_cmk_rotation_enabled.py
+++ b/library/aws/tests/kms/test_kms_cmk_rotation_enabled.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest.mock import MagicMock
+from botocore.exceptions import ClientError
 from tevico.engine.entities.report.check_model import (
     CheckStatus,
     CheckMetadata,
@@ -46,11 +47,9 @@ class TestKMSCMKRotationEnabled:
         self.mock_session.client.return_value = self.mock_kms_client
 
     def test_rotation_enabled_for_customer_cmk(self):
-        # Mock list_keys response with one key
         self.mock_kms_client.list_keys.side_effect = [
             {"Keys": [{"KeyId": "key-123"}], "NextMarker": None}
         ]
-        # Mock describe_key for enabled customer key
         self.mock_kms_client.describe_key.return_value = {
             "KeyMetadata": {
                 "KeyId": "key-123",
@@ -59,7 +58,6 @@ class TestKMSCMKRotationEnabled:
                 "KeyState": "Enabled",
             }
         }
-        # Mock get_key_rotation_status returning rotation enabled
         self.mock_kms_client.get_key_rotation_status.return_value = {
             "KeyRotationEnabled": True
         }
@@ -68,16 +66,14 @@ class TestKMSCMKRotationEnabled:
 
         assert report.status == CheckStatus.PASSED
         assert any(
-            r.summary and "rotation is enabled" in r.summary.lower()
+            r.summary and "rotation is enabled" in r.summary.lower() and "key-123" in r.summary
             for r in report.resource_ids_status
         )
 
     def test_rotation_not_enabled_for_customer_cmk(self):
-        # Mock list_keys response with one key
         self.mock_kms_client.list_keys.side_effect = [
             {"Keys": [{"KeyId": "key-456"}], "NextMarker": None}
         ]
-        # Mock describe_key for enabled customer key
         self.mock_kms_client.describe_key.return_value = {
             "KeyMetadata": {
                 "KeyId": "key-456",
@@ -86,7 +82,6 @@ class TestKMSCMKRotationEnabled:
                 "KeyState": "Enabled",
             }
         }
-        # Mock get_key_rotation_status returning rotation disabled
         self.mock_kms_client.get_key_rotation_status.return_value = {
             "KeyRotationEnabled": False
         }
@@ -95,17 +90,15 @@ class TestKMSCMKRotationEnabled:
 
         assert report.status == CheckStatus.FAILED
         assert any(
-            r.summary and "rotation is not enabled" in r.summary.lower()
+            r.summary and "rotation is not enabled" in r.summary.lower() and "key-456" in r.summary
             for r in report.resource_ids_status
         )
 
     def test_non_customer_or_disabled_keys_are_ignored(self):
-        # Mock list_keys response with keys that are AWS-managed or disabled
         self.mock_kms_client.list_keys.side_effect = [
             {"Keys": [{"KeyId": "key-789"}, {"KeyId": "key-000"}], "NextMarker": None}
         ]
-        # First key is AWS-managed
-        # Second key is customer but disabled
+
         def describe_key_side_effect(KeyId):
             if KeyId == "key-789":
                 return {
@@ -125,21 +118,13 @@ class TestKMSCMKRotationEnabled:
                         "KeyState": "Disabled",
                     }
                 }
-            else:
-                return {}
 
         self.mock_kms_client.describe_key.side_effect = describe_key_side_effect
 
         report = self.check.execute(self.mock_session)
 
-        # Since no eligible keys found, report status should be NOT_APPLICABLE or PASSED
-        # But per your original check logic, no eligible keys means NOT_APPLICABLE
-        assert report.status == CheckStatus.NOT_APPLICABLE or report.status == CheckStatus.PASSED
-        # The resource_ids_status should have at least one entry for no customer-managed keys
-        assert any(
-            r.summary and "no customer-managed cmks found" in r.summary.lower()
-            for r in report.resource_ids_status
-        ) or len(report.resource_ids_status) == 0
+        assert report.status == CheckStatus.PASSED
+        assert report.resource_ids_status == []
 
     def test_error_fetching_keys(self):
         self.mock_kms_client.list_keys.side_effect = Exception("Simulated API failure")
@@ -164,14 +149,37 @@ class TestKMSCMKRotationEnabled:
                 "KeyState": "Enabled",
             }
         }
-        self.mock_kms_client.get_key_rotation_status.side_effect = Exception(
-            "Rotation status error"
+        self.mock_kms_client.get_key_rotation_status.side_effect = Exception("Rotation status error")
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.UNKNOWN
+        assert any(
+            r.summary and "error retrieving rotation status" in r.summary.lower() and "key-999" in r.summary
+            for r in report.resource_ids_status
+        )
+
+    def test_client_error_handling(self):
+        self.mock_kms_client.list_keys.side_effect = [
+            {"Keys": [{"KeyId": "key-888"}], "NextMarker": None}
+        ]
+        self.mock_kms_client.describe_key.return_value = {
+            "KeyMetadata": {
+                "KeyId": "key-888",
+                "Arn": "arn:aws:kms:region:acct:key/key-888",
+                "KeyManager": "CUSTOMER",
+                "KeyState": "Enabled",
+            }
+        }
+        self.mock_kms_client.get_key_rotation_status.side_effect = ClientError(
+            error_response={"Error": {"Code": "AccessDenied", "Message": "Access Denied"}},
+            operation_name="GetKeyRotationStatus"
         )
 
         report = self.check.execute(self.mock_session)
 
         assert report.status == CheckStatus.UNKNOWN
         assert any(
-            r.summary and "error retrieving rotation status" in r.summary.lower()
+            r.summary and "access denied" in r.summary.lower() and "key-888" in r.summary
             for r in report.resource_ids_status
         )


### PR DESCRIPTION
Context
This test suite is designed to validate the functionality of the kms_cmk_rotation_enabled check, which ensures automatic key rotation is enabled for AWS KMS Customer Managed Keys (CMKs). Regular key rotation enhances security by reducing the risk of cryptographic key compromise.

Purpose
To verify that the check correctly identifies:
Customer-managed KMS keys
Their enabled/disabled state
Whether automatic key rotation is turned on
Appropriate handling of invalid, irrelevant, or error conditions

Test Scenarios Covered

-  Rotation Enabled for Customer CMK : Ensures the check returns PASSED when a customer-managed key has automatic rotation enabled.
-  Rotation Not Enabled for Customer CMK : Validates that the check returns FAILED when rotation is explicitly disabled for a valid customer-managed and enabled key.
-  Non-Customer or Disabled Keys Ignored : Confirms that AWS-managed keys and disabled customer keys are skipped, and if no eligible keys remain, the check returns NOT_APPLICABLE with a relevant summary.
-  KMS API Key Listing Failure : Simulates a failure in listing keys and expects the check to return UNKNOWN with a clear error  summary.

Error Retrieving Rotation Status : Simulates a failure while retrieving the rotation status for an otherwise valid key, and expects the check to return UNKNOWN.

Key Features
Uses unittest.mock.MagicMock to simulate AWS API responses.
Validates both high-level check status and detailed resource-level summaries.
Ensures robust error handling and avoids false positives/negatives in complex real-world configurations.

 Checklist
 Detects automatic key rotation status for eligible CMKs.
 Filters out non-customer and disabled keys appropriately.
 Handles AWS API failures gracefully.
 Provides human-readable, actionable summaries.

