### PR TITLE
Test s3 bucket default encryption

### DIFF
--- a/library/aws/tests/rds/test_rds_backup_enabled.py
+++ b/library/aws/tests/rds/test_rds_backup_enabled.py
@@ -1,0 +1,107 @@
+"""
+Test for RDS instance backup enabled check.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+from botocore.exceptions import ClientError
+
+from library.aws.checks.rds.rds_instance_backup_enabled import rds_instance_backup_enabled
+from tevico.engine.entities.report.check_model import CheckStatus, CheckMetadata
+from tevico.engine.entities.report.check_model import Remediation, RemediationCode, RemediationRecommendation
+
+
+class TestRdsInstanceBackupEnabled:
+    """Test cases for RDS instance backup enabled check."""
+
+    def setup_method(self):
+        """Set up test method."""
+        metadata = CheckMetadata(
+            Provider="aws",
+            CheckID="rds_instance_backup_enabled",
+            CheckTitle="Ensure RDS instances have backup enabled.",
+            CheckType=["data-protection"],
+            ServiceName="rds",
+            SubServiceName="",
+            ResourceIdTemplate="arn:aws:rds:region:account-id:db-instance",
+            Severity="medium",
+            ResourceType="AwsRdsDbInstance",
+            Description="Ensure RDS instances have backup enabled.",
+            Risk="If backup is not enabled, data is vulnerable.",
+            RelatedUrl="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.html",
+            Remediation=Remediation(
+                Code=RemediationCode(
+                    CLI="aws rds modify-db-instance --db-instance-identifier <db_instance_id> --backup-retention-period 7 --apply-immediately",
+                    Terraform="https://docs.prowler.com/checks/aws/general-policies/ensure-that-rds-instances-have-backup-policy#terraform",
+                    NativeIaC=None,
+                    Other="https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/rds-automated-backups-enabled.html"
+                ),
+                Recommendation=RemediationRecommendation(
+                    Text="Enable automated backup for production data. Define a retention period and periodically test backup restoration.",
+                    Url="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.html"
+                )
+            ),
+            Categories=["data-protection"]
+        )
+
+        self.check = rds_instance_backup_enabled(metadata)
+        self.mock_session = MagicMock()
+        self.mock_client = MagicMock()
+        self.mock_session.client.return_value = self.mock_client
+
+    def test_backup_enabled(self):
+        """Test when backup is enabled for the RDS instance."""
+        self.mock_client.describe_db_instances.return_value = {
+            "DBInstances": [{
+                "DBInstanceIdentifier": "test-db",
+                "DBInstanceArn": "arn:aws:rds:region:account:db:test-db",
+                "BackupRetentionPeriod": 7
+            }]
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.PASSED
+        assert report.resource_ids_status[0].status == CheckStatus.PASSED
+        assert "Backup is enabled with retention period of 7 days" in report.resource_ids_status[0].summary
+
+    def test_backup_disabled(self):
+        """Test when backup is disabled (retention period is 0)."""
+        self.mock_client.describe_db_instances.return_value = {
+            "DBInstances": [{
+                "DBInstanceIdentifier": "test-db",
+                "DBInstanceArn": "arn:aws:rds:region:account:db:test-db",
+                "BackupRetentionPeriod": 0
+            }]
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.FAILED
+        assert report.resource_ids_status[0].status == CheckStatus.FAILED
+        assert "Backup is NOT enabled for RDS instance" in report.resource_ids_status[0].summary
+
+    def test_no_rds_instances(self):
+        """Test when there are no RDS instances in the account."""
+        self.mock_client.describe_db_instances.return_value = {
+            "DBInstances": []
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.NOT_APPLICABLE
+        assert report.resource_ids_status[0].status == CheckStatus.NOT_APPLICABLE
+        assert "No RDS instances found." in report.resource_ids_status[0].summary
+
+    def test_client_error(self):
+        """Test when the client throws an error during describe call."""
+        self.mock_client.describe_db_instances.side_effect = ClientError(
+            error_response={"Error": {"Code": "InternalFailure", "Message": "Something went wrong"}},
+            operation_name="DescribeDBInstances"
+        )
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.UNKNOWN
+        assert report.resource_ids_status[0].status == CheckStatus.UNKNOWN
+        assert "Error retrieving RDS instance details." in report.resource_ids_status[0].summary

--- a/library/aws/tests/rds/test_rds_instance_deletion_protection.py
+++ b/library/aws/tests/rds/test_rds_instance_deletion_protection.py
@@ -1,0 +1,68 @@
+import pytest
+from unittest.mock import MagicMock
+from tevico.engine.entities.report.check_model import CheckStatus
+from library.aws.checks.rds.rds_instance_deletion_protection import rds_instance_deletion_protection
+
+
+class TestRdsInstanceDeletionProtection:
+    def setup_method(self):
+        metadata = {
+            "CheckID": "rds_instance_deletion_protection",
+            "Provider": "aws",
+            "ServiceName": "rds"
+        }
+        self.check = rds_instance_deletion_protection(metadata=metadata)
+        self.mock_session = MagicMock()
+        self.mock_client = MagicMock()
+        self.mock_session.client.return_value = self.mock_client
+
+    def test_rds_instance_with_deletion_protection(self):
+        """Test case where RDS instance has deletion protection enabled."""
+        self.mock_client.describe_db_instances.return_value = {
+            "DBInstances": [
+                {
+                    "DBInstanceIdentifier": "test-instance-1",
+                    "DBInstanceArn": "arn:aws:rds:region:account-id:db:test-instance-1",
+                    "DeletionProtection": True,
+                }
+            ]
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.PASSED
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.PASSED
+        assert "Deletion protection is enabled" in report.resource_ids_status[0].summary
+
+    def test_rds_instance_without_deletion_protection(self):
+        """Test case where RDS instance has deletion protection disabled."""
+        self.mock_client.describe_db_instances.return_value = {
+            "DBInstances": [
+                {
+                    "DBInstanceIdentifier": "test-instance-2",
+                    "DBInstanceArn": "arn:aws:rds:region:account-id:db:test-instance-2",
+                    "DeletionProtection": False,
+                }
+            ]
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.FAILED
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.FAILED
+        assert "Deletion protection is NOT enabled" in report.resource_ids_status[0].summary
+
+    def test_no_rds_instances_present(self):
+        """Test case where there are no RDS instances in the account."""
+        self.mock_client.describe_db_instances.return_value = {
+            "DBInstances": []
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.NOT_APPLICABLE
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.NOT_APPLICABLE
+        assert "No RDS instances found" in report.resource_ids_status[0].summary

--- a/library/aws/tests/s3/test_s3_bucket_default_encryption.py
+++ b/library/aws/tests/s3/test_s3_bucket_default_encryption.py
@@ -1,0 +1,122 @@
+import pytest
+from unittest.mock import MagicMock
+from botocore.exceptions import ClientError
+
+from library.aws.checks.s3.s3_bucket_default_encryption import s3_bucket_default_encryption
+from tevico.engine.entities.report.check_model import CheckStatus, CheckMetadata, AwsResource, ResourceStatus
+from tevico.engine.entities.report.check_model import Remediation, RemediationCode, RemediationRecommendation
+
+
+class TestS3BucketDefaultEncryption:
+    """Test cases for S3 bucket default encryption check."""
+
+    def setup_method(self):
+        """Set up test method."""
+        metadata = CheckMetadata(
+            Provider="aws",
+            CheckID="s3_bucket_default_encryption",
+            CheckTitle="Ensure S3 buckets have default encryption (SSE) enabled and use a bucket policy to enforce it.",
+            CheckType=["Data Protection"],
+            ServiceName="s3",
+            SubServiceName="",
+            ResourceIdTemplate="arn:partition:s3:::bucket_name",
+            Severity="medium",
+            ResourceType="AwsS3Bucket",
+            Risk="Amazon S3 default encryption provides a way to set the default encryption behavior for an S3 bucket. This will ensure data-at-rest is encrypted.",
+            RelatedUrl="",
+            Remediation=Remediation(
+                Code=RemediationCode(
+                    CLI="aws s3api put-bucket-encryption --bucket <bucket_name> --server-side-encryption-configuration '{\"Rules\": [{\"ApplyServerSideEncryptionByDefault\": {\"SSEAlgorithm\": \"AES256\"}}]}'",
+                    Terraform="",
+                    NativeIaC="",
+                    Other=""
+                ),
+                Recommendation=RemediationRecommendation(
+                    Text="Ensure that S3 buckets have encryption at rest enabled.",
+                    Url="https://aws.amazon.com/blogs/security/how-to-prevent-uploads-of-unencrypted-objects-to-amazon-s3/"
+                )
+            ),
+            Description="Ensure that S3 buckets have default encryption (SSE) enabled and use a bucket policy to enforce it.",
+            Categories=["encryption"]
+        )
+
+        self.check = s3_bucket_default_encryption(metadata)
+        self.mock_session = MagicMock()
+        self.mock_client = MagicMock()
+        self.mock_session.client.return_value = self.mock_client
+
+    def infer_report_status(self, report):
+        """Infer report.status manually based on individual resource statuses."""
+        statuses = [r.status for r in report.resource_ids_status]
+        if CheckStatus.FAILED in statuses:
+            return CheckStatus.FAILED
+        elif CheckStatus.UNKNOWN in statuses:
+            return CheckStatus.UNKNOWN
+        elif all(s == CheckStatus.PASSED for s in statuses):
+            return CheckStatus.PASSED
+        return None
+
+    def test_bucket_with_kms_encryption(self):
+        """Test when S3 bucket has KMS default encryption enabled."""
+        self.mock_client.get_paginator.return_value.paginate.return_value = [
+            {"Buckets": [{"Name": "secure-bucket"}]}
+        ]
+        self.mock_client.get_bucket_encryption.return_value = {
+            'ServerSideEncryptionConfiguration': {
+                'Rules': [{
+                    'ApplyServerSideEncryptionByDefault': {
+                        'SSEAlgorithm': 'aws:kms',
+                        'KMSMasterKeyID': 'alias/aws/s3'
+                    }
+                }]
+            }
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        inferred_status = self.infer_report_status(report)
+        assert inferred_status == CheckStatus.PASSED
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.PASSED
+        assert "default encryption enabled using KMS key" in report.resource_ids_status[0].summary
+
+    def test_bucket_with_aes256_encryption(self):
+        """Test when S3 bucket has AES256 (SSE-S3) default encryption enabled."""
+        self.mock_client.get_paginator.return_value.paginate.return_value = [
+            {"Buckets": [{"Name": "basic-encrypted-bucket"}]}
+        ]
+        self.mock_client.get_bucket_encryption.return_value = {
+            'ServerSideEncryptionConfiguration': {
+                'Rules': [{
+                    'ApplyServerSideEncryptionByDefault': {
+                        'SSEAlgorithm': 'AES256'
+                    }
+                }]
+            }
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        inferred_status = self.infer_report_status(report)
+        assert inferred_status == CheckStatus.PASSED
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.PASSED
+        assert "default encryption enabled using Amazon S3-managed keys" in report.resource_ids_status[0].summary
+
+    def test_bucket_without_encryption(self):
+        """Test when S3 bucket does not have default encryption enabled."""
+        self.mock_client.get_paginator.return_value.paginate.return_value = [
+            {"Buckets": [{"Name": "unencrypted-bucket"}]}
+        ]
+        self.mock_client.get_bucket_encryption.side_effect = ClientError(
+            error_response={"Error": {"Code": "ServerSideEncryptionConfigurationNotFoundError"}},
+            operation_name="GetBucketEncryption"
+        )
+
+        report = self.check.execute(self.mock_session)
+
+        inferred_status = self.infer_report_status(report)
+        assert inferred_status == CheckStatus.FAILED
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.FAILED
+        assert "does not have default encryption enabled" in report.resource_ids_status[0].summary

--- a/library/aws/tests/s3/test_s3_bucket_object_versioning.py
+++ b/library/aws/tests/s3/test_s3_bucket_object_versioning.py
@@ -1,0 +1,108 @@
+"""
+Test for S3 bucket object versioning check.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+from botocore.exceptions import ClientError
+from library.aws.checks.s3.s3_bucket_object_versioning import s3_bucket_object_versioning
+from tevico.engine.entities.report.check_model import (
+    CheckStatus,
+    CheckMetadata,
+    Remediation,
+    RemediationCode,
+    RemediationRecommendation,
+)
+
+
+class TestS3BucketObjectVersioning:
+    """Test cases for S3 bucket object versioning check."""
+
+    def setup_method(self):
+        """Set up test method."""
+        metadata = CheckMetadata(
+            Provider="aws",
+            CheckID="s3_bucket_object_versioning",
+            CheckTitle="Ensure S3 buckets have object versioning enabled",
+            CheckType=["Data Protection", "Disaster Recovery"],
+            ServiceName="s3",
+            SubServiceName="",
+            ResourceIdTemplate="arn:partition:s3:::bucket_name",
+            Severity="medium",
+            ResourceType="AwsS3Bucket",
+            Risk="Without versioning, accidentally deleted or overwritten objects cannot be recovered.",
+            RelatedUrl="https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html",
+            Remediation=Remediation(
+                Code=RemediationCode(
+                    CLI="aws s3api put-bucket-versioning --bucket my-bucket-name --versioning-configuration Status=Enabled",
+                    Terraform='''resource "aws_s3_bucket" "example" {
+  bucket = "my-bucket-name"
+}
+
+resource "aws_s3_bucket_versioning" "example" {
+  bucket = aws_s3_bucket.example.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}''',
+                    NativeIaC=None,
+                    Other=None,
+                ),
+                Recommendation=RemediationRecommendation(
+                    Text="Enable versioning for S3 buckets containing important data.",
+                    Url="https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html",
+                ),
+            ),
+            Description="Ensure S3 buckets have object versioning enabled to protect against accidental deletion and provide data recovery capabilities.",
+            Categories=[],
+        )
+
+        self.check = s3_bucket_object_versioning(metadata)
+        self.mock_session = MagicMock()
+        self.mock_client = MagicMock()
+        self.mock_session.client.return_value = self.mock_client
+
+    def test_bucket_with_versioning_enabled(self):
+        """Test when a bucket has versioning enabled."""
+        self.mock_client.get_paginator.return_value.paginate.return_value = [
+            {"Buckets": [{"Name": "versioned-bucket"}]}
+        ]
+        self.mock_client.get_bucket_versioning.return_value = {"Status": "Enabled"}
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.resource_ids_status[0].status == CheckStatus.PASSED
+        assert "has object versioning enabled" in report.resource_ids_status[0].summary
+
+    def test_bucket_with_versioning_suspended(self):
+        """Test when a bucket has versioning suspended."""
+        self.mock_client.get_paginator.return_value.paginate.return_value = [
+            {"Buckets": [{"Name": "suspended-bucket"}]}
+        ]
+        self.mock_client.get_bucket_versioning.return_value = {"Status": "Suspended"}
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.resource_ids_status[0].status == CheckStatus.FAILED
+        assert "has object versioning suspended" in report.resource_ids_status[0].summary
+
+    def test_bucket_with_no_versioning_config(self):
+        """Test when a bucket has no versioning configuration."""
+        self.mock_client.get_paginator.return_value.paginate.return_value = [
+            {"Buckets": [{"Name": "unversioned-bucket"}]}
+        ]
+        self.mock_client.get_bucket_versioning.return_value = {}
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.resource_ids_status[0].status == CheckStatus.FAILED
+        assert "does not have object versioning enabled" in report.resource_ids_status[0].summary
+
+    def test_no_buckets_present(self):
+        """Test when no S3 buckets are present in the account."""
+        self.mock_client.get_paginator.return_value.paginate.return_value = [{"Buckets": []}]
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.NOT_APPLICABLE
+        assert "No S3 buckets found" in report.resource_ids_status[0].summary

--- a/library/aws/tests/secretsmanager/test_secrets_manager_automatic_rotation_enabled.py
+++ b/library/aws/tests/secretsmanager/test_secrets_manager_automatic_rotation_enabled.py
@@ -1,0 +1,106 @@
+import pytest
+from unittest.mock import MagicMock
+from library.aws.checks.secretsmanager.secrets_manager_automatic_rotation_enabled import secrets_manager_automatic_rotation_enabled
+from tevico.engine.entities.report.check_model import (
+    CheckStatus,
+    CheckMetadata,
+    Remediation,
+    RemediationCode,
+    RemediationRecommendation,
+)
+
+class TestSecretsManagerAutomaticRotation:
+    """Test cases for Secrets Manager automatic rotation check."""
+
+    def setup_method(self):
+        """Set up mock client, session, and metadata."""
+
+        metadata = CheckMetadata(
+            Provider="aws",
+            CheckID="secrets_manager_automatic_rotation_enabled",
+            CheckTitle="Ensure Secrets Manager secrets have automatic rotation enabled.",
+            CheckType=[],
+            ServiceName="secretsmanager",
+            SubServiceName="",
+            ResourceIdTemplate="arn:aws:secretsmanager:region:account-id:secret",
+            Severity="medium",
+            ResourceType="AwsSecretsManagerSecret",
+            Description="Ensure that automatic rotation is enabled for all Secrets Manager secrets.",
+            Risk="Secrets without automatic rotation are at risk of stale credentials, increasing the chance of unauthorized access.",
+            RelatedUrl="https://docs.aws.amazon.com/secretsmanager/latest/userguide/enable-rotation.html",
+            Remediation=Remediation(
+                Code=RemediationCode(
+                    CLI="aws secretsmanager rotate-secret --secret-id <secret-id>",
+                    Terraform=None,
+                    NativeIaC=None,
+                    Other="https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/SecretsManager/secrets-manager-enable-auto-rotation.html"
+                ),
+                Recommendation=RemediationRecommendation(
+                    Text="Enable automatic rotation for all Secrets Manager secrets.",
+                    Url="https://docs.aws.amazon.com/secretsmanager/latest/userguide/enable-rotation.html"
+                )
+            ),
+            Categories=[],
+        )
+
+        self.check = secrets_manager_automatic_rotation_enabled(metadata)
+        self.mock_session = MagicMock()
+        self.mock_client = MagicMock()
+        self.mock_session.client.return_value = self.mock_client
+
+    def test_all_secrets_have_rotation_enabled(self):
+        """Test when all secrets have rotation enabled."""
+        self.mock_client.list_secrets.return_value = {
+            "SecretList": [
+                {"ARN": "arn:aws:secretsmanager:region:account-id:secret/secret1", "Name": "secret1", "RotationEnabled": True},
+                {"ARN": "arn:aws:secretsmanager:region:account-id:secret/secret2", "Name": "secret2", "RotationEnabled": True},
+            ]
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.PASSED
+        assert all(r.status == CheckStatus.PASSED for r in report.resource_ids_status)
+        assert len(report.resource_ids_status) == 2
+
+    def test_some_secrets_have_rotation_disabled(self):
+        """Test when some secrets have rotation disabled."""
+        self.mock_client.list_secrets.return_value = {
+            "SecretList": [
+                {"ARN": "arn:aws:secretsmanager:region:account-id:secret/secret1", "Name": "secret1", "RotationEnabled": True},
+                {"ARN": "arn:aws:secretsmanager:region:account-id:secret/secret2", "Name": "secret2", "RotationEnabled": False},
+            ]
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.FAILED
+        assert any(r.status == CheckStatus.FAILED for r in report.resource_ids_status)
+        assert any(r.status == CheckStatus.PASSED for r in report.resource_ids_status)
+        assert len(report.resource_ids_status) == 2
+
+    def test_no_secrets_exist(self):
+        """Test when no secrets exist in the account."""
+        self.mock_client.list_secrets.return_value = {"SecretList": []}
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.NOT_APPLICABLE
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.NOT_APPLICABLE
+        assert "No secrets found" in report.resource_ids_status[0].summary
+
+    def test_all_secrets_have_rotation_disabled(self):
+        """Test when all secrets have rotation disabled."""
+        self.mock_client.list_secrets.return_value = {
+            "SecretList": [
+                {"ARN": "arn:aws:secretsmanager:region:account-id:secret/secret1", "Name": "secret1", "RotationEnabled": False},
+                {"ARN": "arn:aws:secretsmanager:region:account-id:secret/secret2", "Name": "secret2", "RotationEnabled": False},
+            ]
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.FAILED
+        assert all(r.status == CheckStatus.FAILED for r in report.resource_ids_status)
+        assert len(report.resource_ids_status) == 2

--- a/library/aws/tests/securityhub/test_securityhub_enabled.py
+++ b/library/aws/tests/securityhub/test_securityhub_enabled.py
@@ -1,0 +1,92 @@
+import pytest
+from unittest.mock import MagicMock
+from botocore.exceptions import ClientError
+
+from library.aws.checks.securityhub.securityhub_enabled import securityhub_enabled
+from tevico.engine.entities.report.check_model import CheckStatus, CheckMetadata
+from tevico.engine.entities.report.check_model import Remediation, RemediationCode, RemediationRecommendation
+
+
+class TestSecurityHubEnabled:
+    """Test cases for the Security Hub enabled check."""
+
+    def setup_method(self):
+        """Set up the test method."""
+        metadata = CheckMetadata(
+            Provider="aws",
+            CheckID="securityhub_enabled",
+            CheckTitle="Ensure Security Hub is enabled in this region",
+            CheckType=["Logging and Monitoring"],
+            ServiceName="securityhub",
+            SubServiceName="",
+            ResourceIdTemplate="arn:aws:securityhub:{region}:{account_id}:hub/{hub-id}",
+            Severity="medium",
+            ResourceType="AwsSecurityHub",
+            Description="Checks whether AWS Security Hub is enabled in the current region.",
+            Risk="Without Security Hub enabled, AWS accounts lack centralized visibility into security findings.",
+            RelatedUrl="https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-enable-disable.html",
+            Remediation=Remediation(
+                Code=RemediationCode(
+                    CLI="aws securityhub enable-security-hub --enable-default-standards",
+                    Terraform="",
+                    NativeIaC="",
+                    Other=""
+                ),
+                Recommendation=RemediationRecommendation(
+                    Text="Enable Security Hub in each AWS region to get a centralized view of security posture.",
+                    Url="https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-enable-disable.html"
+                )
+            ),
+            Categories=[]
+        )
+
+        self.check = securityhub_enabled(metadata)
+        self.mock_session = MagicMock()
+        self.mock_client = MagicMock()
+        self.mock_session.client.return_value = self.mock_client
+
+        # Set up custom exceptions on the mock client
+        class ResourceNotFoundException(Exception):
+            pass
+
+        class InvalidAccessException(Exception):
+            pass
+
+        self.mock_client.exceptions = MagicMock()
+        self.mock_client.exceptions.ResourceNotFoundException = ResourceNotFoundException
+        self.mock_client.exceptions.InvalidAccessException = InvalidAccessException
+
+    def test_securityhub_enabled_pass(self):
+        """Test when Security Hub is enabled."""
+        self.mock_client.describe_hub.return_value = {
+            'HubArn': 'arn:aws:securityhub:us-east-1:123456789012:hub/default'
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.PASSED
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.PASSED
+        assert "Security Hub is enabled" in report.resource_ids_status[0].summary
+
+    def test_securityhub_not_enabled_resource_not_found(self):
+        """Test when Security Hub is not enabled (ResourceNotFoundException)."""
+        self.mock_client.describe_hub.side_effect = self.mock_client.exceptions.ResourceNotFoundException()
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.FAILED
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.FAILED
+        assert "Security Hub is not enabled" in report.resource_ids_status[0].summary
+
+    def test_securityhub_not_enabled_invalid_access(self):
+        """Test when Security Hub is not enabled (InvalidAccessException)."""
+        self.mock_client.describe_hub.side_effect = self.mock_client.exceptions.InvalidAccessException()
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.FAILED
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.FAILED
+        assert "Security Hub is not enabled" in report.resource_ids_status[0].summary

--- a/library/aws/tests/ssm/test_ssm_ec2instance_automatic_protection_check.py
+++ b/library/aws/tests/ssm/test_ssm_ec2instance_automatic_protection_check.py
@@ -1,0 +1,107 @@
+"""
+Test for SSM EC2 instance termination protection check.
+"""
+import pytest
+from unittest.mock import MagicMock
+from botocore.exceptions import ClientError
+from library.aws.checks.ssm.ssm_ec2instance_automatic_protection_check import ssm_ec2instance_automatic_protection_check
+from tevico.engine.entities.report.check_model import CheckStatus, CheckMetadata
+from tevico.engine.entities.report.check_model import Remediation, RemediationCode, RemediationRecommendation
+class TestSsmEc2InstanceAutomaticProtection:
+    """Test cases for EC2 instances managed by SSM with termination protection check."""
+    def setup_method(self):
+        """Set up method for initializing the check and mocking boto3 clients."""
+        metadata = CheckMetadata(
+            Provider="aws",
+            CheckID="ssm_ec2instance_automatic_protection_check",
+            CheckTitle="Ensure EC2 instances managed by SSM have termination protection enabled",
+            CheckType=["security"],
+            ServiceName="ssm",
+            SubServiceName="ec2",
+            ResourceIdTemplate="arn:aws:ec2:region:account-id:instance/<INSTANCE_ID>",
+            Severity="medium",
+            ResourceType="AwsEc2Instance",
+            Description="Ensure EC2 instances managed by SSM have termination protection enabled to prevent accidental termination.",
+            Risk="If termination protection is not enabled, EC2 instances can be accidentally terminated, leading to data loss or downtime.",
+            RelatedUrl="https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-managed-instances.html",
+            Remediation=Remediation(
+                Code=RemediationCode(
+                    CLI="aws ec2 modify-instance-attribute --instance-id i-1234567890abcdef0 --disable-api-termination",
+                    Terraform='resource "aws_instance" "example" {\n  disable_api_termination = true\n}',
+                    NativeIaC=None,
+                    Other=None
+                ),
+                Recommendation=RemediationRecommendation(
+                    Text="Enable termination protection for EC2 instances managed by SSM.",
+                    Url="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#using-termination-protection"
+                )
+            ),
+            Categories=["security", "instance-management"]
+        )
+        self.check = ssm_ec2instance_automatic_protection_check(metadata)
+        self.mock_session = MagicMock()
+        self.mock_ec2 = MagicMock()
+        self.mock_ssm = MagicMock()
+        self.mock_session.client.side_effect = lambda service_name: {
+            'ec2': self.mock_ec2,
+            'ssm': self.mock_ssm
+        }[service_name]
+    def test_ssm_managed_with_termination_protection_enabled(self):
+        """Test SSM-managed instance with termination protection enabled."""
+        # Mock EC2 paginator response
+        self.mock_ec2.get_paginator.return_value.paginate.return_value = [
+            {"Reservations": [{"Instances": [{"InstanceId": "i-123456", "State": {"Name": "running"}}]}]}
+        ]
+        # Mock termination protection enabled
+        self.mock_ec2.describe_instance_attribute.return_value = {
+            "DisableApiTermination": {"Value": True}
+        }
+        # Mock SSM-managed instance
+        self.mock_ssm.get_paginator.return_value.paginate.return_value = [
+            {"InstanceInformationList": [{"InstanceId": "i-123456"}]}
+        ]
+        report = self.check.execute(self.mock_session)
+        assert report.status == CheckStatus.PASSED
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.PASSED
+        assert "termination protection enabled" in report.resource_ids_status[0].summary
+    def test_ssm_managed_with_termination_protection_disabled(self):
+        """Test SSM-managed instance without termination protection."""
+        self.mock_ec2.get_paginator.return_value.paginate.return_value = [
+            {"Reservations": [{"Instances": [{"InstanceId": "i-234567", "State": {"Name": "running"}}]}]}
+        ]
+        self.mock_ec2.describe_instance_attribute.return_value = {
+            "DisableApiTermination": {"Value": False}
+        }
+        self.mock_ssm.get_paginator.return_value.paginate.return_value = [
+            {"InstanceInformationList": [{"InstanceId": "i-234567"}]}
+        ]
+        report = self.check.execute(self.mock_session)
+        assert report.status == CheckStatus.FAILED
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.FAILED
+        assert "does not have termination protection enabled" in report.resource_ids_status[0].summary
+    def test_running_instances_none_managed_by_ssm(self):
+        """Test running EC2 instances that are not managed by SSM."""
+        self.mock_ec2.get_paginator.return_value.paginate.return_value = [
+            {"Reservations": [{"Instances": [{"InstanceId": "i-345678", "State": {"Name": "running"}}]}]}
+        ]
+        self.mock_ssm.get_paginator.return_value.paginate.return_value = [
+            {"InstanceInformationList": []}
+        ]
+        report = self.check.execute(self.mock_session)
+        assert report.status == CheckStatus.NOT_APPLICABLE
+        assert len(report.resource_ids_status) == 1
+        assert "No EC2 instances are managed by SSM" in report.resource_ids_status[0].summary
+    def test_no_running_ec2_instances(self):
+        """Test when there are no running EC2 instances."""
+        self.mock_ec2.get_paginator.return_value.paginate.return_value = [
+            {"Reservations": [{"Instances": [{"InstanceId": "i-999999", "State": {"Name": "stopped"}}]}]}
+        ]
+        self.mock_ssm.get_paginator.return_value.paginate.return_value = [
+            {"InstanceInformationList": []}
+        ]
+        report = self.check.execute(self.mock_session)
+        assert report.status == CheckStatus.NOT_APPLICABLE
+        assert len(report.resource_ids_status) == 1
+        assert "No running EC2 instances found" in report.resource_ids_status[0].summary

--- a/library/aws/tests/ssm/test_ssm_managed_compliant_patching.py
+++ b/library/aws/tests/ssm/test_ssm_managed_compliant_patching.py
@@ -1,0 +1,119 @@
+import pytest
+from unittest.mock import MagicMock
+from botocore.exceptions import ClientError
+
+from library.aws.checks.ssm.ssm_managed_compliant_patching import ssm_managed_compliant_patching
+from tevico.engine.entities.report.check_model import CheckStatus, CheckMetadata
+from tevico.engine.entities.report.check_model import Remediation, RemediationCode, RemediationRecommendation
+
+
+class TestSsmManagedCompliantPatching:
+    """Test cases for the SSM managed patch compliance check."""
+
+    def setup_method(self):
+        """Set up for each test."""
+        metadata = CheckMetadata(
+            Provider="aws",
+            CheckID="ssm_managed_compliant_patching",
+            CheckTitle="Ensure SSM-managed EC2 instances are patch compliant",
+            CheckType=["operations"],
+            ServiceName="ssm",
+            SubServiceName="patching",
+            ResourceIdTemplate="arn:aws:ec2:{region}:{account_id}:instance/{resource_id}",
+            Severity="medium",
+            ResourceType="AwsEc2Instance",
+            Risk="Non-compliant instances may be vulnerable due to missing critical patches",
+            RelatedUrl="https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-patch.html",
+            Remediation=Remediation(
+                Code=RemediationCode(
+                    CLI="aws ssm describe-instance-patch-states --instance-ids <your-instance-id>",
+                    Terraform=None,
+                    NativeIaC=None,
+                    Other=None
+                ),
+                Recommendation=RemediationRecommendation(
+                    Text="Enable patch compliance scanning and ensure instances are patched",
+                    Url="https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-patch-compliance.html"
+                )
+            ),
+            Description="Checks if SSM managed EC2 instances are compliant with patching requirements",
+            Categories=["operations", "patching"]
+        )
+
+        self.check = ssm_managed_compliant_patching(metadata)
+        self.mock_session = MagicMock()
+        self.mock_client = MagicMock()
+        self.mock_session.client.return_value = self.mock_client
+
+        # Mock describe_instances to return a running instance
+        self.mock_client.describe_instances.return_value = {
+            "Reservations": [
+                {
+                    "Instances": [
+                        {
+                            "InstanceId": "i-0123456789abcdef0",
+                            "State": {"Name": "running"},
+                            "Tags": [{"Key": "Name", "Value": "TestInstance"}]
+                        }
+                    ]
+                }
+            ]
+        }
+
+    def test_compliant_instance(self):
+        """Test when an SSM managed EC2 instance is patch compliant."""
+        self.mock_client.describe_instance_patch_states.return_value = {
+            'InstancePatchStates': [
+                {
+                    'InstanceId': 'i-0123456789abcdef0',
+                    'PatchSummary': {
+                        'ComplianceType': 'Patch',
+                        'CompliantCriticalCount': 5,
+                        'NonCompliantCriticalCount': 0
+                    }
+                }
+            ]
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.PASSED
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.PASSED
+        assert "compliant with patching" in report.resource_ids_status[0].summary.lower()
+
+    def test_non_compliant_instance(self):
+        """Test when an SSM managed EC2 instance is not patch compliant."""
+        self.mock_client.describe_instance_patch_states.return_value = {
+            'InstancePatchStates': [
+                {
+                    'InstanceId': 'i-0123456789abcdef0',
+                    'PatchSummary': {
+                        'ComplianceType': 'Patch',
+                        'CompliantCriticalCount': 3,
+                        'NonCompliantCriticalCount': 2
+                    }
+                }
+            ]
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.FAILED
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.FAILED
+        assert "non-compliant with patching" in report.resource_ids_status[0].summary.lower()
+
+    def test_client_error(self):
+        """Test when SSM client throws an error (e.g., permissions or service failure)."""
+        self.mock_client.describe_instance_patch_states.side_effect = ClientError(
+            {"Error": {"Code": "UnauthorizedOperation", "Message": "You are not authorized to perform this operation."}},
+            "DescribeInstancePatchStates"
+        )
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.UNKNOWN
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.UNKNOWN
+        assert "error occurred" in report.resource_ids_status[0].summary.lower()

--- a/library/aws/tests/vpc/test_vpc_flowlogs_enable_logging.py
+++ b/library/aws/tests/vpc/test_vpc_flowlogs_enable_logging.py
@@ -1,0 +1,86 @@
+import pytest
+from unittest.mock import MagicMock
+from library.aws.checks.vpc.vpc_flowlogs_enable_logging import vpc_flowlogs_enable_logging
+from tevico.engine.entities.report.check_model import CheckStatus
+
+
+class TestVPCFlowLogsEnableLogging:
+    """Test cases for VPC Flow Logs enabled check."""
+
+    def setup_method(self):
+        """Set up mock session and client responses."""
+        self.check = vpc_flowlogs_enable_logging(metadata={})
+        self.mock_session = MagicMock()
+        self.mock_client = MagicMock()
+        self.mock_sts = MagicMock()
+
+        # Return appropriate mock client depending on service
+        self.mock_session.client.side_effect = (
+            lambda service_name: self.mock_client if service_name == "ec2" else self.mock_sts
+        )
+
+        self.mock_sts.get_caller_identity.return_value = {
+            "Account": "123456789012"
+        }
+
+    def test_all_vpcs_have_flow_logs_enabled(self):
+        """Test when all VPCs have flow logs enabled."""
+        self.mock_client.describe_vpcs.return_value = {
+            "Vpcs": [{"VpcId": "vpc-123"}, {"VpcId": "vpc-456"}]
+        }
+        self.mock_client.describe_flow_logs.side_effect = [
+            {"FlowLogs": [{"FlowLogId": "fl-1"}]},
+            {"FlowLogs": [{"FlowLogId": "fl-2"}]}
+        ]
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.PASSED
+        assert all(r.status == CheckStatus.PASSED for r in report.resource_ids_status)
+        assert len(report.resource_ids_status) == 2
+
+    def test_all_vpcs_have_flow_logs_disabled(self):
+        """Test when all VPCs have flow logs disabled."""
+        self.mock_client.describe_vpcs.return_value = {
+            "Vpcs": [{"VpcId": "vpc-111"}, {"VpcId": "vpc-222"}]
+        }
+        self.mock_client.describe_flow_logs.side_effect = [
+            {"FlowLogs": []},
+            {"FlowLogs": []}
+        ]
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.FAILED
+        assert all(r.status == CheckStatus.FAILED for r in report.resource_ids_status)
+        assert len(report.resource_ids_status) == 2
+
+    def test_some_vpcs_have_flow_logs_disabled(self):
+        """Test when some VPCs have flow logs disabled."""
+        self.mock_client.describe_vpcs.return_value = {
+            "Vpcs": [{"VpcId": "vpc-abc"}, {"VpcId": "vpc-def"}]
+        }
+        self.mock_client.describe_flow_logs.side_effect = [
+            {"FlowLogs": [{"FlowLogId": "fl-abc"}]},
+            {"FlowLogs": []}
+        ]
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.FAILED
+        assert any(r.status == CheckStatus.PASSED for r in report.resource_ids_status)
+        assert any(r.status == CheckStatus.FAILED for r in report.resource_ids_status)
+        assert len(report.resource_ids_status) == 2
+
+    def test_no_vpcs_exist(self):
+        """Test when no VPCs exist in the account."""
+        self.mock_client.describe_vpcs.return_value = {
+            "Vpcs": []
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.NOT_APPLICABLE
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.NOT_APPLICABLE
+        assert "No VPCs found" in report.resource_ids_status[0].summary


### PR DESCRIPTION
### Context
Adding unit tests for the s3_bucket_default_encryption check in Tevico Community Edition to validate the behavior under different encryption configurations for S3 buckets.

### Description
This PR introduces unit tests for the s3_bucket_default_encryption check to ensure it behaves correctly in the following scenarios:
Bucket has KMS-based default encryption.
Bucket has AES256-based default encryption.
Bucket has no default encryption configured.

### Checklist
-Added new tests for s3_bucket_default_encryption
 -Code covered by tests
 -No additional permissions required
 -No backporting required at this time

### License
I confirm that my contribution is made under the terms of the **Apache 2.0 license**.
