### PR TITLE
Add Unit Tests for acm_certificates_expiration_check

### DIFF
--- a/library/aws/tests/acm/test_acm_certificates_expiration_check.py
+++ b/library/aws/tests/acm/test_acm_certificates_expiration_check.py
@@ -1,0 +1,146 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from datetime import datetime, timedelta, timezone
+from tevico.engine.entities.report.check_model import (
+    CheckStatus,
+    CheckMetadata,
+    Remediation,
+    RemediationCode,
+    RemediationRecommendation,
+)
+from library.aws.checks.acm.acm_certificates_expiration_check import acm_certificates_expiration_check
+
+
+@pytest.fixture
+def test_metadata():
+    return CheckMetadata(
+        Provider="AWS",
+        CheckID="acm_certificates_expiration_check",
+        CheckTitle="Check ACM Certificate Expiration",
+        CheckType=["Security"],
+        ServiceName="ACM",
+        SubServiceName="Certificate",
+        ResourceIdTemplate="arn:aws:acm:{region}:{account}:certificate/{certificate_id}",
+        Severity="medium",
+        ResourceType="AWS::ACM::Certificate",
+        Risk="Expired certificates can cause outages.",
+        Description="Checks for ACM certificates that are expired or expiring soon.",
+        Remediation=Remediation(
+            Code=RemediationCode(CLI="", NativeIaC="", Terraform=""),
+            Recommendation=RemediationRecommendation(
+                Text="Renew or replace expiring ACM certificates.",
+                Url="https://docs.aws.amazon.com/acm/latest/userguide/managed-renewal.html"
+            )
+        )
+    )
+
+
+@pytest.fixture
+def check_instance(test_metadata):
+    return acm_certificates_expiration_check(metadata=test_metadata)
+
+
+def get_mock_session(mock_acm):
+    mock_session = MagicMock()
+    mock_session.client.return_value = mock_acm
+    return mock_session
+
+
+@patch("boto3.Session.client")
+def test_no_certificates(mock_client, check_instance):
+    mock_acm = MagicMock()
+    mock_acm.list_certificates.return_value = {"CertificateSummaryList": []}
+    mock_client.return_value = mock_acm
+
+    report = check_instance.execute(get_mock_session(mock_acm))
+
+    assert report.status == CheckStatus.NOT_APPLICABLE
+    assert "No ACM certificates found" in report.resource_ids_status[0].summary
+
+
+@patch("boto3.Session.client")
+def test_certificate_expired(mock_client, check_instance):
+    mock_acm = MagicMock()
+    cert_arn = "arn:aws:acm:region:account:certificate/expired"
+    mock_acm.list_certificates.return_value = {
+        "CertificateSummaryList": [{"CertificateArn": cert_arn}]
+    }
+    expired_date = datetime.now(timezone.utc) - timedelta(days=2)
+    mock_acm.describe_certificate.return_value = {
+        "Certificate": {"NotAfter": expired_date}
+    }
+    mock_client.return_value = mock_acm
+
+    report = check_instance.execute(get_mock_session(mock_acm))
+
+    assert report.status == CheckStatus.FAILED
+    assert "already expired" in report.resource_ids_status[0].summary
+
+
+@patch("boto3.Session.client")
+def test_certificate_expiring_soon(mock_client, check_instance):
+    mock_acm = MagicMock()
+    cert_arn = "arn:aws:acm:region:account:certificate/soon"
+    mock_acm.list_certificates.return_value = {
+        "CertificateSummaryList": [{"CertificateArn": cert_arn}]
+    }
+    # Use 3 days + few minutes to avoid truncation in business logic
+    soon_date = datetime.now(timezone.utc) + timedelta(days=3, minutes=5)
+    mock_acm.describe_certificate.return_value = {
+        "Certificate": {"NotAfter": soon_date}
+    }
+    mock_client.return_value = mock_acm
+
+    report = check_instance.execute(get_mock_session(mock_acm))
+
+    assert report.status == CheckStatus.FAILED
+    assert "expires in 3 days" in report.resource_ids_status[0].summary
+
+@patch("boto3.Session.client")
+def test_certificate_valid_longer(mock_client, check_instance):
+    mock_acm = MagicMock()
+    cert_arn = "arn:aws:acm:region:account:certificate/valid"
+    mock_acm.list_certificates.return_value = {
+        "CertificateSummaryList": [{"CertificateArn": cert_arn}]
+    }
+    # Add buffer to avoid edge cut-off
+    valid_date = datetime.now(timezone.utc) + timedelta(days=30, minutes=5)
+    mock_acm.describe_certificate.return_value = {
+        "Certificate": {"NotAfter": valid_date}
+    }
+    mock_client.return_value = mock_acm
+
+    report = check_instance.execute(get_mock_session(mock_acm))
+
+    assert report.status == CheckStatus.PASSED
+    assert "valid for 30 more days" in report.resource_ids_status[0].summary
+
+
+@patch("boto3.Session.client")
+def test_describe_certificate_error(mock_client, check_instance):
+    mock_acm = MagicMock()
+    cert_arn = "arn:aws:acm:region:account:certificate/error"
+    mock_acm.list_certificates.return_value = {
+        "CertificateSummaryList": [{"CertificateArn": cert_arn}]
+    }
+    mock_acm.describe_certificate.side_effect = Exception("Describe error")
+    mock_client.return_value = mock_acm
+
+    report = check_instance.execute(get_mock_session(mock_acm))
+
+    assert report.status == CheckStatus.FAILED
+    assert report.resource_ids_status[0].status == CheckStatus.UNKNOWN
+    assert "Error describing certificate" in report.resource_ids_status[0].summary
+
+
+@patch("boto3.Session.client")
+def test_list_certificates_error(mock_client, check_instance):
+    mock_acm = MagicMock()
+    mock_acm.list_certificates.side_effect = Exception("List error")
+    mock_client.return_value = mock_acm
+
+    report = check_instance.execute(get_mock_session(mock_acm))
+
+    assert report.status == CheckStatus.UNKNOWN
+    assert report.resource_ids_status[0].status == CheckStatus.FAILED
+    assert "Error fetching ACM certificates" in report.resource_ids_status[0].summary

--- a/library/aws/tests/acm/test_acm_certificates_expiration_check.py
+++ b/library/aws/tests/acm/test_acm_certificates_expiration_check.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import MagicMock
 from datetime import datetime, timedelta, timezone
+
 from tevico.engine.entities.report.check_model import (
     CheckStatus,
     CheckMetadata,
@@ -11,127 +12,111 @@ from tevico.engine.entities.report.check_model import (
 from library.aws.checks.acm.acm_certificates_expiration_check import acm_certificates_expiration_check
 
 
-@pytest.fixture
-def test_metadata():
-    return CheckMetadata(
-        Provider="AWS",
-        CheckID="acm_certificates_expiration_check",
-        CheckTitle="Check ACM Certificate Expiration",
-        CheckType=["Security"],
-        ServiceName="ACM",
-        SubServiceName="Certificate",
-        ResourceIdTemplate="arn:aws:acm:{region}:{account}:certificate/{certificate_id}",
-        Severity="medium",
-        ResourceType="AWS::ACM::Certificate",
-        Risk="Expired certificates can cause outages.",
-        Description="Checks for ACM certificates that are expired or expiring soon.",
-        Remediation=Remediation(
-            Code=RemediationCode(CLI="", NativeIaC="", Terraform=""),
-            Recommendation=RemediationRecommendation(
-                Text="Renew or replace expiring ACM certificates.",
-                Url="https://docs.aws.amazon.com/acm/latest/userguide/managed-renewal.html"
+class TestAcmCertificatesExpirationCheck:
+    """Test cases for ACM certificate expiration check."""
+
+    def setup_method(self):
+        """Set up test metadata and mocked session."""
+        metadata = CheckMetadata(
+            Provider="AWS",
+            CheckID="acm_certificates_expiration_check",
+            CheckTitle="Check ACM Certificate Expiration",
+            CheckType=["Security"],
+            ServiceName="ACM",
+            SubServiceName="Certificate",
+            ResourceIdTemplate="arn:aws:acm:{region}:{account}:certificate/{certificate_id}",
+            Severity="medium",
+            ResourceType="AWS::ACM::Certificate",
+            Risk="Expired certificates can cause outages.",
+            Description="Checks for ACM certificates that are expired or expiring soon.",
+            Remediation=Remediation(
+                Code=RemediationCode(CLI="", NativeIaC="", Terraform=""),
+                Recommendation=RemediationRecommendation(
+                    Text="Renew or replace expiring ACM certificates.",
+                    Url="https://docs.aws.amazon.com/acm/latest/userguide/managed-renewal.html"
+                )
             )
         )
-    )
 
+        self.check = acm_certificates_expiration_check(metadata=metadata)
+        self.mock_client = MagicMock()
 
-@pytest.fixture
-def check_instance(test_metadata):
-    return acm_certificates_expiration_check(metadata=test_metadata)
+        # Wrap session so .client('acm') returns mock client
+        self.mock_session = MagicMock()
+        self.mock_session.client.return_value = self.mock_client
 
+    def test_no_certificates(self):
+        self.mock_client.list_certificates.return_value = {"CertificateSummaryList": []}
 
-def get_mock_session(mock_acm):
-    mock_session = MagicMock()
-    mock_session.client.return_value = mock_acm
-    return mock_session
+        report = self.check.execute(self.mock_session)
 
+        assert report.status == CheckStatus.NOT_APPLICABLE
+        assert "No ACM certificates found" in report.resource_ids_status[0].summary
 
-def test_no_certificates(check_instance):
-    mock_acm = MagicMock()
-    mock_acm.list_certificates.return_value = {"CertificateSummaryList": []}
+    def test_certificate_expired(self):
+        cert_arn = "arn:aws:acm:region:account:certificate/expired"
+        self.mock_client.list_certificates.return_value = {
+            "CertificateSummaryList": [{"CertificateArn": cert_arn}]
+        }
+        self.mock_client.describe_certificate.return_value = {
+            "Certificate": {"NotAfter": datetime.now(timezone.utc) - timedelta(days=2)}
+        }
 
-    report = check_instance.execute(get_mock_session(mock_acm))
+        report = self.check.execute(self.mock_session)
 
-    assert report.status == CheckStatus.NOT_APPLICABLE
-    assert "No ACM certificates found" in report.resource_ids_status[0].summary
+        assert report.status == CheckStatus.FAILED
+        assert report.resource_ids_status[0].resource.arn == cert_arn
+        assert "already expired" in report.resource_ids_status[0].summary
 
+    def test_certificate_expiring_soon(self):
+        cert_arn = "arn:aws:acm:region:account:certificate/soon"
+        self.mock_client.list_certificates.return_value = {
+            "CertificateSummaryList": [{"CertificateArn": cert_arn}]
+        }
+        self.mock_client.describe_certificate.return_value = {
+            "Certificate": {"NotAfter": datetime.now(timezone.utc) + timedelta(days=3, minutes=5)}
+        }
 
-def test_certificate_expired(check_instance):
-    mock_acm = MagicMock()
-    cert_arn = "arn:aws:acm:region:account:certificate/expired"
-    mock_acm.list_certificates.return_value = {
-        "CertificateSummaryList": [{"CertificateArn": cert_arn}]
-    }
-    expired_date = datetime.now(timezone.utc) - timedelta(days=2)
-    mock_acm.describe_certificate.return_value = {
-        "Certificate": {"NotAfter": expired_date}
-    }
+        report = self.check.execute(self.mock_session)
 
-    report = check_instance.execute(get_mock_session(mock_acm))
+        assert report.status == CheckStatus.FAILED
+        assert report.resource_ids_status[0].resource.arn == cert_arn
+        assert "expires in 3 days" in report.resource_ids_status[0].summary
 
-    assert report.status == CheckStatus.FAILED
-    assert report.resource_ids_status[0].resource.arn == cert_arn
-    assert "already expired" in report.resource_ids_status[0].summary
+    def test_certificate_valid_longer(self):
+        cert_arn = "arn:aws:acm:region:account:certificate/valid"
+        self.mock_client.list_certificates.return_value = {
+            "CertificateSummaryList": [{"CertificateArn": cert_arn}]
+        }
+        self.mock_client.describe_certificate.return_value = {
+            "Certificate": {"NotAfter": datetime.now(timezone.utc) + timedelta(days=30, minutes=5)}
+        }
 
+        report = self.check.execute(self.mock_session)
 
-def test_certificate_expiring_soon(check_instance):
-    mock_acm = MagicMock()
-    cert_arn = "arn:aws:acm:region:account:certificate/soon"
-    mock_acm.list_certificates.return_value = {
-        "CertificateSummaryList": [{"CertificateArn": cert_arn}]
-    }
-    soon_date = datetime.now(timezone.utc) + timedelta(days=3, minutes=5)
-    mock_acm.describe_certificate.return_value = {
-        "Certificate": {"NotAfter": soon_date}
-    }
+        assert report.status == CheckStatus.PASSED
+        assert report.resource_ids_status[0].resource.arn == cert_arn
+        assert "valid for 30 more days" in report.resource_ids_status[0].summary
 
-    report = check_instance.execute(get_mock_session(mock_acm))
+    def test_describe_certificate_error(self):
+        cert_arn = "arn:aws:acm:region:account:certificate/error"
+        self.mock_client.list_certificates.return_value = {
+            "CertificateSummaryList": [{"CertificateArn": cert_arn}]
+        }
+        self.mock_client.describe_certificate.side_effect = Exception("Describe error")
 
-    assert report.status == CheckStatus.FAILED
-    assert report.resource_ids_status[0].resource.arn == cert_arn
-    assert "expires in 3 days" in report.resource_ids_status[0].summary
+        report = self.check.execute(self.mock_session)
 
+        assert report.status == CheckStatus.FAILED
+        assert report.resource_ids_status[0].status == CheckStatus.UNKNOWN
+        assert report.resource_ids_status[0].resource.arn == cert_arn
+        assert "Error describing certificate" in report.resource_ids_status[0].summary
 
-def test_certificate_valid_longer(check_instance):
-    mock_acm = MagicMock()
-    cert_arn = "arn:aws:acm:region:account:certificate/valid"
-    mock_acm.list_certificates.return_value = {
-        "CertificateSummaryList": [{"CertificateArn": cert_arn}]
-    }
-    valid_date = datetime.now(timezone.utc) + timedelta(days=30, minutes=5)
-    mock_acm.describe_certificate.return_value = {
-        "Certificate": {"NotAfter": valid_date}
-    }
+    def test_list_certificates_error(self):
+        self.mock_client.list_certificates.side_effect = Exception("List error")
 
-    report = check_instance.execute(get_mock_session(mock_acm))
+        report = self.check.execute(self.mock_session)
 
-    assert report.status == CheckStatus.PASSED
-    assert report.resource_ids_status[0].resource.arn == cert_arn
-    assert "valid for 30 more days" in report.resource_ids_status[0].summary
-
-
-def test_describe_certificate_error(check_instance):
-    mock_acm = MagicMock()
-    cert_arn = "arn:aws:acm:region:account:certificate/error"
-    mock_acm.list_certificates.return_value = {
-        "CertificateSummaryList": [{"CertificateArn": cert_arn}]
-    }
-    mock_acm.describe_certificate.side_effect = Exception("Describe error")
-
-    report = check_instance.execute(get_mock_session(mock_acm))
-
-    assert report.status == CheckStatus.FAILED
-    assert report.resource_ids_status[0].status == CheckStatus.UNKNOWN
-    assert report.resource_ids_status[0].resource.arn == cert_arn
-    assert "Error describing certificate" in report.resource_ids_status[0].summary
-
-
-def test_list_certificates_error(check_instance):
-    mock_acm = MagicMock()
-    mock_acm.list_certificates.side_effect = Exception("List error")
-
-    report = check_instance.execute(get_mock_session(mock_acm))
-
-    assert report.status == CheckStatus.UNKNOWN
-    assert report.resource_ids_status[0].status == CheckStatus.FAILED
-    assert "Error fetching ACM certificates" in report.resource_ids_status[0].summary
+        assert report.status == CheckStatus.UNKNOWN
+        assert report.resource_ids_status[0].status == CheckStatus.FAILED
+        assert "Error fetching ACM certificates" in report.resource_ids_status[0].summary


### PR DESCRIPTION
### **Context**

Adding unit test coverage for the `acm_certificates_expiration_check` implemented under `library/aws/checks/acm/`.
This ensures correctness across various ACM certificate states (expired, expiring soon, valid, no certificates, and errors).


### **Description**

* Created `test_acm_certificates_expiration_check.py` in `library/aws/tests/acm/`
* Test cases added:

  * No ACM certificates
  * Expired certificate
  * Certificate expiring in less than 7 days
  * Valid certificate (more than 7 days remaining)
  * Error while describing certificate
  * Error while listing certificates

Dependencies:

* Relies on `pytest` and `unittest.mock`
* No external AWS resources required due to mocking


### **Checklist**

* [x] Added new tests for existing check
* [x] Verified all tests cover various execution paths and edge cases
* [x] Code covered by tests
* [x] Follows [[Google Python Style Guide](https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings)](https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings)
* [x] No backporting required
* [x] Confirmed that mocking avoids actual AWS API calls



### **License**

I confirm that my contribution is made under the terms of the **Apache 2.0 license**.
