### PR TITLE
added test case for test_vpc_flowlogs_enable_logging

### DIFF
--- a/library/aws/tests/vpc/test_vpc_flowlogs_enable_logging.py
+++ b/library/aws/tests/vpc/test_vpc_flowlogs_enable_logging.py
@@ -1,0 +1,129 @@
+import pytest
+from unittest.mock import MagicMock
+from botocore.exceptions import ClientError
+
+from library.aws.checks.vpc.vpc_flowlogs_enable_logging import vpc_flowlogs_enable_logging
+from tevico.engine.entities.report.check_model import CheckStatus, CheckMetadata
+from tevico.engine.entities.report.check_model import Remediation, RemediationCode, RemediationRecommendation
+
+
+class TestVPCFlowLogsEnableLogging:
+    """Test cases for VPC Flow Logs enabled check."""
+
+    def setup_method(self):
+        """Set up mock session and client responses."""
+
+        metadata = CheckMetadata(
+            Provider="aws",
+            CheckID="vpc_flowlogs_enable_logging",
+            CheckTitle="Ensure VPC Flow Logs are enabled for all VPCs.",
+            CheckType=["security", "monitoring"],
+            ServiceName="ec2",
+            SubServiceName="",
+            ResourceIdTemplate="arn:aws:ec2:{region}:{account_id}:vpc/{vpc_id}",
+            Severity="medium",
+            ResourceType="AwsVpc",
+            Risk="Without VPC Flow Logs enabled, there is no visibility into the network traffic.",
+            RelatedUrl="https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html",
+            Remediation=Remediation(
+                Code=RemediationCode(
+                    CLI="aws ec2 create-flow-logs --resource-type VPC --resource-id <vpc_id> --traffic-type ALL --log-group-name <log_group_name> --deliver-logs-permission-arn <role_arn>",
+                    NativeIaC=None,
+                    Terraform=None,
+                    Other="https://aws.amazon.com/premiumsupport/knowledge-center/vpc-flow-logs-cloudwatch/"
+                ),
+                Recommendation=RemediationRecommendation(
+                    Text="Enable VPC Flow Logs for all VPCs using the AWS Management Console or CLI.",
+                    Url="https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html"
+                )
+            ),
+            Description="Ensure VPC Flow Logs are enabled for all VPCs to monitor network traffic.",
+            Categories=["security", "monitoring"]
+        )
+
+        self.check = vpc_flowlogs_enable_logging(metadata)
+        self.mock_session = MagicMock()
+        self.mock_client = MagicMock()
+        self.mock_sts = MagicMock()
+
+        self.mock_session.client.side_effect = (
+            lambda service_name: self.mock_client if service_name == "ec2" else self.mock_sts
+        )
+
+        self.mock_sts.get_caller_identity.return_value = {
+            "Account": "123456789012"
+        }
+
+    def test_all_vpcs_have_flow_logs_enabled(self):
+        """Test when all VPCs have flow logs enabled."""
+        self.mock_client.describe_vpcs.return_value = {
+            "Vpcs": [{"VpcId": "vpc-123"}, {"VpcId": "vpc-456"}]
+        }
+        self.mock_client.describe_flow_logs.side_effect = [
+            {"FlowLogs": [{"FlowLogId": "fl-1"}]},
+            {"FlowLogs": [{"FlowLogId": "fl-2"}]}
+        ]
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.PASSED
+        assert len(report.resource_ids_status) == 2
+        assert all(r.status == CheckStatus.PASSED for r in report.resource_ids_status)
+
+    def test_all_vpcs_have_flow_logs_disabled(self):
+        """Test when all VPCs have flow logs disabled."""
+        self.mock_client.describe_vpcs.return_value = {
+            "Vpcs": [{"VpcId": "vpc-111"}, {"VpcId": "vpc-222"}]
+        }
+        self.mock_client.describe_flow_logs.side_effect = [
+            {"FlowLogs": []},
+            {"FlowLogs": []}
+        ]
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.FAILED
+        assert len(report.resource_ids_status) == 2
+        assert all(r.status == CheckStatus.FAILED for r in report.resource_ids_status)
+
+    def test_some_vpcs_have_flow_logs_disabled(self):
+        """Test when some VPCs have flow logs disabled."""
+        self.mock_client.describe_vpcs.return_value = {
+            "Vpcs": [{"VpcId": "vpc-abc"}, {"VpcId": "vpc-def"}]
+        }
+        self.mock_client.describe_flow_logs.side_effect = [
+            {"FlowLogs": [{"FlowLogId": "fl-abc"}]},
+            {"FlowLogs": []}
+        ]
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.FAILED
+        assert len(report.resource_ids_status) == 2
+        assert any(r.status == CheckStatus.PASSED for r in report.resource_ids_status)
+        assert any(r.status == CheckStatus.FAILED for r in report.resource_ids_status)
+
+    def test_no_vpcs_exist(self):
+        """Test when no VPCs exist in the account."""
+        self.mock_client.describe_vpcs.return_value = {
+            "Vpcs": []
+        }
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.NOT_APPLICABLE
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.NOT_APPLICABLE
+        assert "No VPCs found" in report.resource_ids_status[0].summary
+
+    def test_client_error_handling(self):
+        """Test error handling when a ClientError occurs."""
+        error_response = {'Error': {'Code': 'UnauthorizedOperation', 'Message': 'Access denied'}}
+        self.mock_client.describe_vpcs.side_effect = ClientError(error_response, 'DescribeVpcs')
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.UNKNOWN
+        assert len(report.resource_ids_status) == 1
+        assert report.resource_ids_status[0].status == CheckStatus.UNKNOWN
+        assert "Error fetching VPCs" in report.resource_ids_status[0].summary

--- a/library/aws/tests/vpc/test_vpc_flowlogs_enable_logging.py
+++ b/library/aws/tests/vpc/test_vpc_flowlogs_enable_logging.py
@@ -54,15 +54,17 @@ class TestVPCFlowLogsEnableLogging:
             "Account": "123456789012"
         }
 
+    def set_vpc_flow_logs(self, vpcs, flow_logs_side_effect):
+        """Helper method to mock VPCs and corresponding flow logs."""
+        self.mock_client.describe_vpcs.return_value = {"Vpcs": vpcs}
+        self.mock_client.describe_flow_logs.side_effect = flow_logs_side_effect
+
     def test_all_vpcs_have_flow_logs_enabled(self):
         """Test when all VPCs have flow logs enabled."""
-        self.mock_client.describe_vpcs.return_value = {
-            "Vpcs": [{"VpcId": "vpc-123"}, {"VpcId": "vpc-456"}]
-        }
-        self.mock_client.describe_flow_logs.side_effect = [
-            {"FlowLogs": [{"FlowLogId": "fl-1"}]},
-            {"FlowLogs": [{"FlowLogId": "fl-2"}]}
-        ]
+        self.set_vpc_flow_logs(
+            [{"VpcId": "vpc-123"}, {"VpcId": "vpc-456"}],
+            [{"FlowLogs": [{"FlowLogId": "fl-1"}]}, {"FlowLogs": [{"FlowLogId": "fl-2"}]}]
+        )
 
         report = self.check.execute(self.mock_session)
 
@@ -72,13 +74,10 @@ class TestVPCFlowLogsEnableLogging:
 
     def test_all_vpcs_have_flow_logs_disabled(self):
         """Test when all VPCs have flow logs disabled."""
-        self.mock_client.describe_vpcs.return_value = {
-            "Vpcs": [{"VpcId": "vpc-111"}, {"VpcId": "vpc-222"}]
-        }
-        self.mock_client.describe_flow_logs.side_effect = [
-            {"FlowLogs": []},
-            {"FlowLogs": []}
-        ]
+        self.set_vpc_flow_logs(
+            [{"VpcId": "vpc-111"}, {"VpcId": "vpc-222"}],
+            [{"FlowLogs": []}, {"FlowLogs": []}]
+        )
 
         report = self.check.execute(self.mock_session)
 
@@ -88,13 +87,10 @@ class TestVPCFlowLogsEnableLogging:
 
     def test_some_vpcs_have_flow_logs_disabled(self):
         """Test when some VPCs have flow logs disabled."""
-        self.mock_client.describe_vpcs.return_value = {
-            "Vpcs": [{"VpcId": "vpc-abc"}, {"VpcId": "vpc-def"}]
-        }
-        self.mock_client.describe_flow_logs.side_effect = [
-            {"FlowLogs": [{"FlowLogId": "fl-abc"}]},
-            {"FlowLogs": []}
-        ]
+        self.set_vpc_flow_logs(
+            [{"VpcId": "vpc-abc"}, {"VpcId": "vpc-def"}],
+            [{"FlowLogs": [{"FlowLogId": "fl-abc"}]}, {"FlowLogs": []}]
+        )
 
         report = self.check.execute(self.mock_session)
 
@@ -105,9 +101,7 @@ class TestVPCFlowLogsEnableLogging:
 
     def test_no_vpcs_exist(self):
         """Test when no VPCs exist in the account."""
-        self.mock_client.describe_vpcs.return_value = {
-            "Vpcs": []
-        }
+        self.mock_client.describe_vpcs.return_value = {"Vpcs": []}
 
         report = self.check.execute(self.mock_session)
 
@@ -117,7 +111,7 @@ class TestVPCFlowLogsEnableLogging:
         assert "No VPCs found" in report.resource_ids_status[0].summary
 
     def test_client_error_handling(self):
-        """Test error handling when a ClientError occurs."""
+        """Test error handling when a ClientError occurs in describe_vpcs."""
         error_response = {'Error': {'Code': 'UnauthorizedOperation', 'Message': 'Access denied'}}
         self.mock_client.describe_vpcs.side_effect = ClientError(error_response, 'DescribeVpcs')
 
@@ -127,3 +121,28 @@ class TestVPCFlowLogsEnableLogging:
         assert len(report.resource_ids_status) == 1
         assert report.resource_ids_status[0].status == CheckStatus.UNKNOWN
         assert "Error fetching VPCs" in report.resource_ids_status[0].summary
+
+    def test_flow_logs_missing_key(self):
+        """Test when 'FlowLogs' key is missing in describe_flow_logs response."""
+        self.set_vpc_flow_logs(
+            [{"VpcId": "vpc-999"}],
+            [{}]  # Missing 'FlowLogs' key
+        )
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.FAILED or report.status == CheckStatus.UNKNOWN
+        assert report.resource_ids_status[0].status in [CheckStatus.FAILED, CheckStatus.UNKNOWN]
+
+    def test_flow_logs_api_failure(self):
+        """Test ClientError from describe_flow_logs."""
+        self.set_vpc_flow_logs(
+            [{"VpcId": "vpc-fail"}],
+            [ClientError({'Error': {'Code': 'AccessDenied', 'Message': 'Denied'}}, 'DescribeFlowLogs')]
+        )
+
+        report = self.check.execute(self.mock_session)
+
+        assert report.status == CheckStatus.UNKNOWN
+        assert report.resource_ids_status[0].status == CheckStatus.UNKNOWN
+        assert "error" in report.resource_ids_status[0].summary.lower()


### PR DESCRIPTION

### Context

Adding a new test case to verify whether VPC Flow Logs are enabled for all VPCs as part of the AWS security best practices.
Fixes incorrect or missing coverage for `vpc_flowlogs_enable_logging`.

---

### Description

* Implemented `test_vpc_flowlogs_enable_logging.py` under `library/aws/testcases/vpc/`
* Added tests for scenarios:

  * All VPCs have flow logs enabled
  * All VPCs have flow logs disabled
  * Some VPCs have flow logs disabled
  * No VPCs exist
  * Client error handling (e.g., `UnauthorizedOperation`)
* Uses `MagicMock` to simulate `boto3` EC2 client responses
* Aligns structure and metadata with `iam_password_policy_lowercase` test format for consistency

---

### Checklist

* [x] Added new checks? If yes, reviewed necessary permissions
* [x] Code covered by tests
* [x] Documentation follows [[Google Python Style Guide](https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings)](https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings)
* [x] Considered if backporting is needed

---

###  License

I confirm that my contribution is made under the terms of the **Apache 2.0 license**.

